### PR TITLE
Full merge rework

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -73,7 +73,7 @@ IncludeCategories:
     Priority: 1
 IncludeIsMainRegex: '(Test)?$'
 IndentCaseLabels: false
-#IndentPPDirectives: None # Unknown to clang-format-5.0
+IndentPPDirectives: BeforeHash
 IndentWidth: 8
 IndentWrappedFunctionNames: false
 JavaScriptQuotes: Leave

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ set(BENCHMARK OFF CACHE BOOL "Build benchmarks")
 set(TEST OFF CACHE BOOL "Build tests")
 
 project(ProPauli
-	VERSION 3.0.1
+	VERSION 3.1.0
 DESCRIPTION "Fast and efficient C++ library for Pauli Propagation"
 	LANGUAGES CXX)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,15 @@ FetchContent_Declare(
 	GIT_TAG v1.4.0
 )
 FetchContent_MakeAvailable(robin-map)
-target_link_libraries(propaulib tsl::robin_map)
+
+FetchContent_Declare(
+  xxhash
+  GIT_REPOSITORY https://github.com/Cyan4973/xxHash.git
+  GIT_TAG        v0.8.3
+)
+FetchContent_MakeAvailable(xxhash)
+
+target_link_libraries(propaulib tsl::robin_map xxhash)
 
 if (TEST)
 	# Build de GTest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,10 +72,11 @@ FetchContent_Declare(
   xxhash
   GIT_REPOSITORY https://github.com/Cyan4973/xxHash.git
   GIT_TAG        v0.8.3
+  SOURCE_SUBDIR  cmake_unofficial
 )
 FetchContent_MakeAvailable(xxhash)
 
-target_link_libraries(propaulib tsl::robin_map xxhash)
+target_link_libraries(propaulib PUBLIC tsl::robin_map xxhash)
 
 if (TEST)
 	# Build de GTest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,12 +61,6 @@ target_link_options(propaulib INTERFACE
 	)
 
 include(FetchContent)
-FetchContent_Declare(
-	robin-map
-	GIT_REPOSITORY https://github.com/Tessil/robin-map
-	GIT_TAG v1.4.0
-)
-FetchContent_MakeAvailable(robin-map)
 
 FetchContent_Declare(
   xxhash
@@ -76,7 +70,7 @@ FetchContent_Declare(
 )
 FetchContent_MakeAvailable(xxhash)
 
-target_link_libraries(propaulib PUBLIC tsl::robin_map xxhash)
+target_link_libraries(propaulib PUBLIC xxhash)
 
 if (TEST)
 	# Build de GTest

--- a/benchmarks/qaoa_maxcut.cpp
+++ b/benchmarks/qaoa_maxcut.cpp
@@ -1,0 +1,340 @@
+#include <benchmark/benchmark.h>
+
+#include "circuit.hpp"
+#include "observable.hpp"
+
+#include "helper.hpp"
+#include <memory>
+#include <string_view>
+
+// nx.random_regular_graph(d=3, n=32, seed=6)
+class MergeMaxCutQAOAN32P3 : public benchmark::Fixture {
+    public:
+	static constexpr std::array<std::string_view, 3 * 16> sv_obss = {
+		"ZIIZIIIIIIIIIIIIIIIIIIIIIIIIIIII", "IZIIIZIIIIIIIIIIIIIIIIIIIIIIIIII", "IIZIIZIIIIIIIIIIIIIIIIIIIIIIIIII",
+		"IIIIZIZIIIIIIIIIIIIIIIIIIIIIIIII", "IIZIIIIIIZIIIIIIIIIIIIIIIIIIIIII", "IIIIIZIIIZIIIIIIIIIIIIIIIIIIIIII",
+		"ZIIIIIIIIIIZIIIIIIIIIIIIIIIIIIII", "IIIIIIIZIIIIIZIIIIIIIIIIIIIIIIII", "IIIIIIIIIIIZIZIIIIIIIIIIIIIIIIII",
+		"IZIIIIIIIIIIIIZIIIIIIIIIIIIIIIII", "IIIIIIIIIIZIIIZIIIIIIIIIIIIIIIII", "ZIIIIIIIIIIIIIIZIIIIIIIIIIIIIIII",
+		"IIIIIIIIZIIIIIIZIIIIIIIIIIIIIIII", "IIIIIIIIIIIIIIZZIIIIIIIIIIIIIIII", "IIIIZIIIIIIIIIIIIIZIIIIIIIIIIIII",
+		"IIIIIIIZIIIIIIIIIIZIIIIIIIIIIIII", "IIIIIIIIIIIIZIIIIIZIIIIIIIIIIIII", "IIZIIIIIIIIIIIIIIIIZIIIIIIIIIIII",
+		"IIIIIIIIZIIIIIIIIIIZIIIIIIIIIIII", "IIIIIIIIIIIIZIIIIIIZIIIIIIIIIIII", "IIIIIIZIIIIIIIIIIIIIZIIIIIIIIIII",
+		"IIIIIIIIIIIIIIIIZIIIZIIIIIIIIIII", "IIIIIIIIIIIIIIIIIZIIIZIIIIIIIIII", "IIIZIIIIIIIIIIIIIIIIIIZIIIIIIIII",
+		"IIIIIIIIIIIIZIIIIIIIIIZIIIIIIIII", "IIIZIIIIIIIIIIIIIIIIIIIZIIIIIIII", "IIIIIIZIIIIIIIIIIIIIIIIZIIIIIIII",
+		"IIIIIIIIIIZIIIIIIIIIIIIIZIIIIIII", "IIIIIIIIIIIIIIIIIZIIIIIIZIIIIIII", "IIIIIIIZIIIIIIIIIIIIIIIIIZIIIIII",
+		"IIIIIIIIIIIIIIIIIZIIIIIIIZIIIIII", "IIIIIIIIIIIIIIIIIIIIIZIIIZIIIIII", "IIIIZIIIIIIIIIIIIIIIIIIIIIZIIIII",
+		"IIIIIIIIIIIIIIIIZIIIIIIIIIZIIIII", "IZIIIIIIIIIIIIIIIIIIIIIIIIIZIIII", "IIIIIIIIIZIIIIIIIIIIIIIIIIIZIIII",
+		"IIIIIIIIIIZIIIIIIIIIIIIIIIIZIIII", "IIIIIIIIIIIIIZIIIIIIIIIIIIIIZIII", "IIIIIIIIIIIIIIIIIIIIIZIIIIIIZIII",
+		"IIIIIIIIIIIIIIIIIIIIZIIIIIIIIZII", "IIIIIIIIIIIIIIIIIIIIIIIIIIZIIZII", "IIIIIIIIIIIIIIIIIIIIIIIIIIIIZZII",
+		"IIIIIIIIZIIIIIIIIIIIIIIIIIIIIIZI", "IIIIIIIIIIIZIIIIIIIIIIIIIIIIIIZI", "IIIIIIIIIIIIIIIIIIIIIIZIIIIIIIZI",
+		"IIIIIIIIIIIIIIIIZIIIIIIIIIIIIIIZ", "IIIIIIIIIIIIIIIIIIIIIIIZIIIIIIIZ", "IIIIIIIIIIIIIIIIIIIIIIIIZIIIIIIZ"
+	};
+	Observable<coeff_t> obs;
+	Circuit<coeff_t> qc{ 32 };
+
+	MergeMaxCutQAOAN32P3() : obs{ sv_obss.begin(), sv_obss.end() } {}
+	void SetUp([[maybe_unused]] benchmark::State const& state) override {
+		qc.add_operation("H", 0);
+		qc.add_operation("H", 1);
+		qc.add_operation("H", 2);
+		qc.add_operation("H", 3);
+		qc.add_operation("H", 4);
+		qc.add_operation("H", 5);
+		qc.add_operation("H", 6);
+		qc.add_operation("H", 7);
+		qc.add_operation("H", 8);
+		qc.add_operation("H", 9);
+		qc.add_operation("H", 10);
+		qc.add_operation("H", 11);
+		qc.add_operation("H", 12);
+		qc.add_operation("H", 13);
+		qc.add_operation("H", 14);
+		qc.add_operation("H", 15);
+		qc.add_operation("H", 16);
+		qc.add_operation("H", 17);
+		qc.add_operation("H", 18);
+		qc.add_operation("H", 19);
+		qc.add_operation("H", 20);
+		qc.add_operation("H", 21);
+		qc.add_operation("H", 22);
+		qc.add_operation("H", 23);
+		qc.add_operation("H", 24);
+		qc.add_operation("H", 25);
+		qc.add_operation("H", 26);
+		qc.add_operation("H", 27);
+		qc.add_operation("H", 28);
+		qc.add_operation("H", 29);
+		qc.add_operation("H", 30);
+		qc.add_operation("H", 31);
+		rzz(qc, 0, 11, 0.422);
+		rzz(qc, 0, 3, 0.422);
+		rzz(qc, 0, 15, 0.422);
+		rzz(qc, 1, 27, 0.422);
+		rzz(qc, 1, 5, 0.422);
+		rzz(qc, 1, 14, 0.422);
+		rzz(qc, 2, 5, 0.422);
+		rzz(qc, 2, 19, 0.422);
+		rzz(qc, 2, 9, 0.422);
+		rzz(qc, 3, 22, 0.422);
+		rzz(qc, 3, 23, 0.422);
+		rzz(qc, 4, 6, 0.422);
+		rzz(qc, 4, 18, 0.422);
+		rzz(qc, 4, 26, 0.422);
+		rzz(qc, 5, 9, 0.422);
+		rzz(qc, 6, 20, 0.422);
+		rzz(qc, 6, 23, 0.422);
+		rzz(qc, 7, 13, 0.422);
+		rzz(qc, 7, 25, 0.422);
+		rzz(qc, 7, 18, 0.422);
+		rzz(qc, 8, 15, 0.422);
+		rzz(qc, 8, 30, 0.422);
+		rzz(qc, 8, 19, 0.422);
+		rzz(qc, 9, 27, 0.422);
+		rzz(qc, 10, 24, 0.422);
+		rzz(qc, 10, 27, 0.422);
+		rzz(qc, 10, 14, 0.422);
+		rzz(qc, 11, 13, 0.422);
+		rzz(qc, 11, 30, 0.422);
+		rzz(qc, 12, 19, 0.422);
+		rzz(qc, 12, 22, 0.422);
+		rzz(qc, 12, 18, 0.422);
+		rzz(qc, 13, 28, 0.422);
+		rzz(qc, 14, 15, 0.422);
+		rzz(qc, 16, 20, 0.422);
+		rzz(qc, 16, 26, 0.422);
+		rzz(qc, 16, 31, 0.422);
+		rzz(qc, 17, 21, 0.422);
+		rzz(qc, 17, 24, 0.422);
+		rzz(qc, 17, 25, 0.422);
+		rzz(qc, 20, 29, 0.422);
+		rzz(qc, 21, 28, 0.422);
+		rzz(qc, 21, 25, 0.422);
+		rzz(qc, 22, 30, 0.422);
+		rzz(qc, 23, 31, 0.422);
+		rzz(qc, 24, 31, 0.422);
+		rzz(qc, 26, 29, 0.422);
+		rzz(qc, 28, 29, 0.422);
+		rx(qc, 0, -1.218);
+		rx(qc, 1, -1.218);
+		rx(qc, 2, -1.218);
+		rx(qc, 3, -1.218);
+		rx(qc, 4, -1.218);
+		rx(qc, 5, -1.218);
+		rx(qc, 6, -1.218);
+		rx(qc, 7, -1.218);
+		rx(qc, 8, -1.218);
+		rx(qc, 9, -1.218);
+		rx(qc, 10, -1.218);
+		rx(qc, 11, -1.218);
+		rx(qc, 12, -1.218);
+		rx(qc, 13, -1.218);
+		rx(qc, 14, -1.218);
+		rx(qc, 15, -1.218);
+		rx(qc, 16, -1.218);
+		rx(qc, 17, -1.218);
+		rx(qc, 18, -1.218);
+		rx(qc, 19, -1.218);
+		rx(qc, 20, -1.218);
+		rx(qc, 21, -1.218);
+		rx(qc, 22, -1.218);
+		rx(qc, 23, -1.218);
+		rx(qc, 24, -1.218);
+		rx(qc, 25, -1.218);
+		rx(qc, 26, -1.218);
+		rx(qc, 27, -1.218);
+		rx(qc, 28, -1.218);
+		rx(qc, 29, -1.218);
+		rx(qc, 30, -1.218);
+		rx(qc, 31, -1.218);
+		rzz(qc, 0, 11, 0.798);
+		rzz(qc, 0, 3, 0.798);
+		rzz(qc, 0, 15, 0.798);
+		rzz(qc, 1, 27, 0.798);
+		rzz(qc, 1, 5, 0.798);
+		rzz(qc, 1, 14, 0.798);
+		rzz(qc, 2, 5, 0.798);
+		rzz(qc, 2, 19, 0.798);
+		rzz(qc, 2, 9, 0.798);
+		rzz(qc, 3, 22, 0.798);
+		rzz(qc, 3, 23, 0.798);
+		rzz(qc, 4, 6, 0.798);
+		rzz(qc, 4, 18, 0.798);
+		rzz(qc, 4, 26, 0.798);
+		rzz(qc, 5, 9, 0.798);
+		rzz(qc, 6, 20, 0.798);
+		rzz(qc, 6, 23, 0.798);
+		rzz(qc, 7, 13, 0.798);
+		rzz(qc, 7, 25, 0.798);
+		rzz(qc, 7, 18, 0.798);
+		rzz(qc, 8, 15, 0.798);
+		rzz(qc, 8, 30, 0.798);
+		rzz(qc, 8, 19, 0.798);
+		rzz(qc, 9, 27, 0.798);
+		rzz(qc, 10, 24, 0.798);
+		rzz(qc, 10, 27, 0.798);
+		rzz(qc, 10, 14, 0.798);
+		rzz(qc, 11, 13, 0.798);
+		rzz(qc, 11, 30, 0.798);
+		rzz(qc, 12, 19, 0.798);
+		rzz(qc, 12, 22, 0.798);
+		rzz(qc, 12, 18, 0.798);
+		rzz(qc, 13, 28, 0.798);
+		rzz(qc, 14, 15, 0.798);
+		rzz(qc, 16, 20, 0.798);
+		rzz(qc, 16, 26, 0.798);
+		rzz(qc, 16, 31, 0.798);
+		rzz(qc, 17, 21, 0.798);
+		rzz(qc, 17, 24, 0.798);
+		rzz(qc, 17, 25, 0.798);
+		rzz(qc, 20, 29, 0.798);
+		rzz(qc, 21, 28, 0.798);
+		rzz(qc, 21, 25, 0.798);
+		rzz(qc, 22, 30, 0.798);
+		rzz(qc, 23, 31, 0.798);
+		rzz(qc, 24, 31, 0.798);
+		rzz(qc, 26, 29, 0.798);
+		rzz(qc, 28, 29, 0.798);
+		rx(qc, 0, -0.918);
+		rx(qc, 1, -0.918);
+		rx(qc, 2, -0.918);
+		rx(qc, 3, -0.918);
+		rx(qc, 4, -0.918);
+		rx(qc, 5, -0.918);
+		rx(qc, 6, -0.918);
+		rx(qc, 7, -0.918);
+		rx(qc, 8, -0.918);
+		rx(qc, 9, -0.918);
+		rx(qc, 10, -0.918);
+		rx(qc, 11, -0.918);
+		rx(qc, 12, -0.918);
+		rx(qc, 13, -0.918);
+		rx(qc, 14, -0.918);
+		rx(qc, 15, -0.918);
+		rx(qc, 16, -0.918);
+		rx(qc, 17, -0.918);
+		rx(qc, 18, -0.918);
+		rx(qc, 19, -0.918);
+		rx(qc, 20, -0.918);
+		rx(qc, 21, -0.918);
+		rx(qc, 22, -0.918);
+		rx(qc, 23, -0.918);
+		rx(qc, 24, -0.918);
+		rx(qc, 25, -0.918);
+		rx(qc, 26, -0.918);
+		rx(qc, 27, -0.918);
+		rx(qc, 28, -0.918);
+		rx(qc, 29, -0.918);
+		rx(qc, 30, -0.918);
+		rx(qc, 31, -0.918);
+		rzz(qc, 0, 11, 0.937);
+		rzz(qc, 0, 3, 0.937);
+		rzz(qc, 0, 15, 0.937);
+		rzz(qc, 1, 27, 0.937);
+		rzz(qc, 1, 5, 0.937);
+		rzz(qc, 1, 14, 0.937);
+		rzz(qc, 2, 5, 0.937);
+		rzz(qc, 2, 19, 0.937);
+		rzz(qc, 2, 9, 0.937);
+		rzz(qc, 3, 22, 0.937);
+		rzz(qc, 3, 23, 0.937);
+		rzz(qc, 4, 6, 0.937);
+		rzz(qc, 4, 18, 0.937);
+		rzz(qc, 4, 26, 0.937);
+		rzz(qc, 5, 9, 0.937);
+		rzz(qc, 6, 20, 0.937);
+		rzz(qc, 6, 23, 0.937);
+		rzz(qc, 7, 13, 0.937);
+		rzz(qc, 7, 25, 0.937);
+		rzz(qc, 7, 18, 0.937);
+		rzz(qc, 8, 15, 0.937);
+		rzz(qc, 8, 30, 0.937);
+		rzz(qc, 8, 19, 0.937);
+		rzz(qc, 9, 27, 0.937);
+		rzz(qc, 10, 24, 0.937);
+		rzz(qc, 10, 27, 0.937);
+		rzz(qc, 10, 14, 0.937);
+		rzz(qc, 11, 13, 0.937);
+		rzz(qc, 11, 30, 0.937);
+		rzz(qc, 12, 19, 0.937);
+		rzz(qc, 12, 22, 0.937);
+		rzz(qc, 12, 18, 0.937);
+		rzz(qc, 13, 28, 0.937);
+		rzz(qc, 14, 15, 0.937);
+		rzz(qc, 16, 20, 0.937);
+		rzz(qc, 16, 26, 0.937);
+		rzz(qc, 16, 31, 0.937);
+		rzz(qc, 17, 21, 0.937);
+		rzz(qc, 17, 24, 0.937);
+		rzz(qc, 17, 25, 0.937);
+		rzz(qc, 20, 29, 0.937);
+		rzz(qc, 21, 28, 0.937);
+		rzz(qc, 21, 25, 0.937);
+		rzz(qc, 22, 30, 0.937);
+		rzz(qc, 23, 31, 0.937);
+		rzz(qc, 24, 31, 0.937);
+		rzz(qc, 26, 29, 0.937);
+		rzz(qc, 28, 29, 0.937);
+		rx(qc, 0, -0.47);
+		rx(qc, 1, -0.47);
+		rx(qc, 2, -0.47);
+		rx(qc, 3, -0.47);
+		rx(qc, 4, -0.47);
+		rx(qc, 5, -0.47);
+		rx(qc, 6, -0.47);
+		rx(qc, 7, -0.47);
+		rx(qc, 8, -0.47);
+		rx(qc, 9, -0.47);
+		rx(qc, 10, -0.47);
+		rx(qc, 11, -0.47);
+		rx(qc, 12, -0.47);
+		rx(qc, 13, -0.47);
+		rx(qc, 14, -0.47);
+		rx(qc, 15, -0.47);
+		rx(qc, 16, -0.47);
+		rx(qc, 17, -0.47);
+		rx(qc, 18, -0.47);
+		rx(qc, 19, -0.47);
+		rx(qc, 20, -0.47);
+		rx(qc, 21, -0.47);
+		rx(qc, 22, -0.47);
+		rx(qc, 23, -0.47);
+		rx(qc, 24, -0.47);
+		rx(qc, 25, -0.47);
+		rx(qc, 26, -0.47);
+		rx(qc, 27, -0.47);
+		rx(qc, 28, -0.47);
+		rx(qc, 29, -0.47);
+		rx(qc, 30, -0.47);
+		rx(qc, 31, -0.47);
+	}
+	void TearDown([[maybe_unused]] benchmark::State const& state) override { qc = decltype(qc){ 32 }; }
+	~MergeMaxCutQAOAN32P3() override {}
+};
+
+BENCHMARK_DEFINE_F(MergeMaxCutQAOAN32P3, alwayafter_merge_alwaysafter_keepn50k_run)(benchmark::State& state) {
+	qc.set_merge_policy(std::make_shared<AlwaysAfterSplittingPolicy>());
+	qc.set_truncate_policy(std::make_shared<AlwaysAfterSplittingPolicy>());
+	qc.set_truncator(std::make_shared<KeepNTruncator<coeff_t>>(50000));
+
+	for (auto _ : state) {
+		auto res = qc.run(obs);
+		benchmark::DoNotOptimize(res);
+	}
+}
+
+BENCHMARK_DEFINE_F(MergeMaxCutQAOAN32P3, alwayafter_merge_alwaysafter_keepn10k_run_one_by_one)(benchmark::State& state) {
+	qc.set_merge_policy(std::make_shared<AlwaysAfterSplittingPolicy>());
+	qc.set_truncate_policy(std::make_shared<AlwaysAfterSplittingPolicy>());
+	qc.set_truncator(std::make_shared<KeepNTruncator<coeff_t>>(10000));
+
+	for (auto _ : state) {
+		auto sum_ev = 0.f;
+		for (auto sv : sv_obss) {
+			auto ob = Observable(sv);
+			sum_ev += qc.run(ob).expectation_value();
+		}
+		benchmark::DoNotOptimize(sum_ev);
+	}
+}
+
+BENCHMARK_REGISTER_F(MergeMaxCutQAOAN32P3, alwayafter_merge_alwaysafter_keepn50k_run);
+BENCHMARK_REGISTER_F(MergeMaxCutQAOAN32P3, alwayafter_merge_alwaysafter_keepn10k_run_one_by_one);

--- a/include/container/dirty_set.hpp
+++ b/include/container/dirty_set.hpp
@@ -18,14 +18,14 @@
 template <typename Key, typename Hash = std::hash<Key>, typename KeyEqual = std::equal_to<Key>>
 class DirtySet {
     private:
-// --- Compile-Time Policy Selection ---
-// Select the best available probing policy. To add AVX2, you would add
-// a new policy and an #elif defined(__AVX2__) here.
-#if defined(__SSE2__)
-	using Policy = DirtySetDetail::ProbePolicySSE2;
-#else
-	using Policy = DirtySetDetail::ProbePolicyScalar;
-#endif
+	// --- Compile-Time Policy Selection ---
+	// Select the best available probing policy. To add AVX2, you would add
+	// a new policy and an #elif defined(__AVX2__) here.
+	#if defined(__SSE2__)
+		using Policy = DirtySetDetail::ProbePolicySSE2;
+	#else
+		using Policy = DirtySetDetail::ProbePolicyScalar;
+	#endif
 
 	using Group = typename Policy::Group;
 	using BitMask = DirtySetDetail::BitMask; // BitMask is policy-agnostic for now
@@ -262,7 +262,6 @@ class DirtySet {
 			}
 
 			probe_offset += probe_step++;
-			assert(probe_offset < m_capacity && "Hash table is full, but load factor check failed.");
 		}
 	}
 

--- a/include/container/dirty_set.hpp
+++ b/include/container/dirty_set.hpp
@@ -1,0 +1,405 @@
+#ifndef DIRTY_SET_HPP
+#define DIRTY_SET_HPP
+
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <iterator>
+#include <memory>
+#include <new>
+#include <stdexcept>
+#include <type_traits>
+#include <utility>
+
+template <
+    typename Key,
+    typename Hash = std::hash<Key>,
+    typename KeyEqual = std::equal_to<Key>
+>
+class DirtySet {
+private:
+    // --- Internal Data Structures ---
+
+    struct Metadata {
+        // Full hash is stored to speed up rehashes and equality checks.
+        // Probing can first compare hashes (a cheap size_t comparison)
+        // before calling the potentially expensive KeyEqual functor.
+        size_t stored_hash;
+
+        // Probe Sequence Length (PSL). A measure of how far this element is
+        // from its ideal location.
+        // A PSL of 0 indicates an empty/never-used slot.
+        // A PSL of 1 means the element is in its ideal location.
+        // A PSL > 1 means the element was displaced due to a collision.
+        uint32_t psl = 0;
+    };
+
+public:
+    // --- Type Aliases (STL-compliant) ---
+    using key_type = Key;
+    using value_type = Key;
+    using size_type = size_t;
+    using difference_type = ptrdiff_t;
+    using hasher = Hash;
+    using key_equal = KeyEqual;
+    using reference = value_type&;
+    using const_reference = const value_type&;
+    using pointer = value_type*;
+    using const_pointer = const value_type*;
+
+    // --- Forward Iterator Implementation ---
+    template<bool IsConst>
+    class BasicIterator {
+    public:
+        using iterator_category = std::forward_iterator_tag;
+        using value_type = Key;
+        using difference_type = ptrdiff_t;
+        using pointer = std::conditional_t<IsConst, const Key*, Key*>;
+        using reference = std::conditional_t<IsConst, const Key&, Key&>;
+
+        BasicIterator() noexcept = default;
+
+        reference operator*() const { return m_keys[m_index]; }
+        pointer operator->() const { return &m_keys[m_index]; }
+
+        BasicIterator& operator++() {
+            advance_to_next_full();
+            return *this;
+        }
+
+        BasicIterator operator++(int) {
+            BasicIterator old = *this;
+            ++(*this);
+            return old;
+        }
+
+        // Allow conversion from iterator to const_iterator
+        operator BasicIterator<true>() const {
+            return BasicIterator<true>(m_keys, m_metadata, m_index, m_capacity);
+        }
+
+        friend bool operator==(const BasicIterator& lhs, const BasicIterator& rhs) noexcept {
+            return lhs.m_index == rhs.m_index;
+        }
+        friend bool operator!=(const BasicIterator& lhs, const BasicIterator& rhs) noexcept {
+            return !(lhs == rhs);
+        }
+
+    private:
+        friend class DirtySet;
+        using KeyPtr = std::conditional_t<IsConst, const Key*, Key*>;
+        using MetaPtr = std::conditional_t<IsConst, const Metadata*, Metadata*>;
+
+        BasicIterator(KeyPtr keys, MetaPtr metadata, size_type index, size_type capacity) noexcept
+            : m_keys(keys), m_metadata(metadata), m_index(index), m_capacity(capacity) {}
+
+        void advance_to_next_full() {
+            ++m_index;
+            while (m_index < m_capacity && m_metadata[m_index].psl == 0) {
+                ++m_index;
+            }
+        }
+        
+        KeyPtr m_keys = nullptr;
+        MetaPtr m_metadata = nullptr;
+        size_type m_index = 0;
+        size_type m_capacity = 0;
+    };
+
+    using iterator = BasicIterator<false>;
+    using const_iterator = BasicIterator<true>;
+
+    // --- Constructors, Destructor, Assignment ---
+
+    constexpr DirtySet() noexcept = default;
+
+    ~DirtySet() {
+        destroy_keys();
+    }
+
+    DirtySet(const DirtySet& other) {
+        copy_from(other);
+    }
+
+    DirtySet& operator=(const DirtySet& other) {
+        if (this != &other) {
+            destroy_keys();
+            m_keys.reset();
+            m_metadata.reset();
+            copy_from(other);
+        }
+        return *this;
+    }
+
+    DirtySet(DirtySet&& other) noexcept = default;
+    DirtySet& operator=(DirtySet&& other) noexcept = default;
+
+    // --- Iterators ---
+
+    iterator begin() noexcept {
+        size_type index = 0;
+        while (index < m_capacity && m_metadata[index].psl == 0) {
+            index++;
+        }
+        return iterator(m_keys.get(), m_metadata.get(), index, m_capacity);
+    }
+
+    const_iterator begin() const noexcept {
+        size_type index = 0;
+        while (index < m_capacity && m_metadata[index].psl == 0) {
+            index++;
+        }
+        return const_iterator(m_keys.get(), m_metadata.get(), index, m_capacity);
+    }
+    
+    const_iterator cbegin() const noexcept {
+        return begin();
+    }
+
+    iterator end() noexcept {
+        return iterator(m_keys.get(), m_metadata.get(), m_capacity, m_capacity);
+    }
+
+    const_iterator end() const noexcept {
+        return const_iterator(m_keys.get(), m_metadata.get(), m_capacity, m_capacity);
+    }
+    
+    const_iterator cend() const noexcept {
+        return end();
+    }
+
+    // --- Capacity ---
+
+    [[nodiscard]] bool empty() const noexcept { return m_size == 0; }
+    size_type size() const noexcept { return m_size; }
+
+    void reserve(size_type capacity_hint) {
+        if (capacity_hint == 0) return;
+        size_type new_capacity = next_power_of_two(capacity_hint);
+        if (new_capacity * MAX_LOAD_FACTOR > m_capacity * MAX_LOAD_FACTOR) {
+            rehash(new_capacity);
+        }
+    }
+    
+    // --- Modifiers ---
+
+    void clear() noexcept {
+        destroy_keys();
+        // Keep allocated memory for reuse.
+    }
+    
+    std::pair<iterator, bool> emplace(Key&& key) {
+        if (m_size + 1 > m_capacity * MAX_LOAD_FACTOR) {
+            rehash(m_capacity > 0 ? m_capacity * 2 : 8);
+        }
+        return find_or_insert_impl(std::move(key));
+    }
+
+    template <typename Predicate>
+    size_type erase_if(Predicate pred) {
+        size_type removed_count = 0;
+        for (size_type i = 0; i < m_capacity; ++i) {
+            if (m_metadata[i].psl != 0 && pred(m_keys[i])) {
+                erase_at(i);
+                removed_count++;
+                // After backward-shifting, the element at 'i' is new
+                // and must be re-evaluated.
+                --i;
+            }
+        }
+        return removed_count;
+    }
+
+private:
+    // --- Private Helper Functions ---
+
+    void copy_from(const DirtySet& other) {
+        m_capacity = other.m_capacity;
+        m_size = other.m_size;
+        m_hasher = other.m_hasher;
+        m_key_equal = other.m_key_equal;
+        
+        if (m_capacity > 0) {
+            m_keys = std::make_unique<Key[]>(m_capacity);
+            m_metadata = std::make_unique<Metadata[]>(m_capacity);
+
+            for (size_type i = 0; i < m_capacity; ++i) {
+                m_metadata[i] = other.m_metadata[i];
+                if (m_metadata[i].psl != 0) {
+                    new (&m_keys[i]) Key(other.m_keys[i]);
+                }
+            }
+        }
+    }
+
+    std::pair<iterator, bool> find_or_insert_impl(Key&& key) {
+        const size_t hash = m_hasher(key);
+        size_type index = hash & (m_capacity - 1);
+        uint32_t current_psl = 1;
+
+        while (true) {
+            Metadata& meta = m_metadata[index];
+
+            if (meta.psl == 0) { // Found an empty slot. Insert here.
+                new (&m_keys[index]) Key(std::move(key));
+                meta.stored_hash = hash;
+                meta.psl = current_psl;
+                m_size++;
+                return {iterator(m_keys.get(), m_metadata.get(), index, m_capacity), true};
+            }
+
+            // Cheap hash comparison first, then expensive key comparison.
+            if (meta.stored_hash == hash && m_key_equal(m_keys[index], key)) {
+                return {iterator(m_keys.get(), m_metadata.get(), index, m_capacity), false};
+            }
+            
+            // Robin Hood Hashing: If the element in the current slot is "richer"
+            // (has a smaller PSL) than the element we are trying to insert,
+            // we swap them and continue trying to find a home for the displaced element.
+            if (meta.psl < current_psl) {
+                // Swap metadata
+                std::swap(current_psl, meta.psl);
+                size_t temp_hash;
+                std::swap(temp_hash, meta.stored_hash);
+                std::swap(hash, temp_hash);
+
+                // Swap the key we are trying to insert with the one in the slot.
+                std::swap(key, m_keys[index]);
+            }
+            
+            current_psl++;
+            index = (index + 1) & (m_capacity - 1);
+        }
+    }
+
+    void insert_new(Key&& key, size_t hash) {
+        size_type index = hash & (m_capacity - 1);
+        uint32_t current_psl = 1;
+
+        while (true) {
+            Metadata& meta = m_metadata[index];
+
+            if (meta.psl == 0) { // Found an empty slot. Insert here.
+                new (&m_keys[index]) Key(std::move(key));
+                meta.stored_hash = hash;
+                meta.psl = current_psl;
+                m_size++;
+                return;
+            }
+
+            if (meta.psl < current_psl) {
+                std::swap(current_psl, meta.psl);
+                size_t temp_hash;
+                std::swap(temp_hash, meta.stored_hash);
+                std::swap(hash, temp_hash);
+                std::swap(key, m_keys[index]);
+            }
+
+            current_psl++;
+            index = (index + 1) & (m_capacity - 1);
+        }
+    }
+
+    void erase_at(size_type index) {
+        m_keys[index].~Key(); // Manually destruct the key
+        m_size--;
+
+        // Backward-shift deletion:
+        // Move subsequent elements in the probe chain back one slot to fill the gap.
+        while (true) {
+            size_type current_index = index;
+            size_type next_index = (index + 1) & (m_capacity - 1);
+            
+            Metadata& next_meta = m_metadata[next_index];
+
+            // If the next slot is empty or is in its ideal location, the chain is broken.
+            if (next_meta.psl <= 1) {
+                m_metadata[current_index].psl = 0; // Mark current slot as empty.
+                return;
+            }
+
+            // Move the next element into the current (now empty) slot.
+            new (&m_keys[current_index]) Key(std::move(m_keys[next_index]));
+            m_keys[next_index].~Key();
+
+            m_metadata[current_index] = {next_meta.stored_hash, next_meta.psl - 1};
+
+            index = next_index;
+        }
+    }
+
+    void rehash(size_type new_capacity) {
+        // Keep old arrays alive until we are done moving from them.
+        auto old_keys = std::move(m_keys);
+        auto old_metadata = std::move(m_metadata);
+        size_type old_capacity = m_capacity;
+
+        // Allocate and commit new, empty arrays.
+        m_keys = std::make_unique<Key[]>(new_capacity);
+        m_metadata = std::make_unique<Metadata[]>(new_capacity);
+        m_capacity = new_capacity;
+        m_size = 0; // Reset size, will be incremented by insert_new.
+
+        // Iterate old elements and insert them into the new arrays.
+        for (size_type i = 0; i < old_capacity; ++i) {
+            if (old_metadata[i].psl != 0) {
+                // No re-hashing needed! We just use the stored hash.
+                insert_new(std::move(old_keys[i]), old_metadata[i].stored_hash);
+                old_keys[i].~Key(); // Manually destruct the moved-from key.
+            }
+        }
+        // old_keys and old_metadata are destructed here, freeing the old memory.
+    }
+
+    void destroy_keys() noexcept {
+        if (!m_keys) return;
+        for (size_type i = 0; i < m_capacity; ++i) {
+            if (m_metadata[i].psl != 0) {
+                m_keys[i].~Key();
+                m_metadata[i].psl = 0; // Reset metadata
+            }
+        }
+        m_size = 0;
+    }
+
+    // Finds the smallest power of two that is >= n.
+    static constexpr size_type next_power_of_two(size_type n) {
+        if (n == 0) return 1;
+        // Efficient bit-twiddling algorithm.
+        n--;
+        n |= n >> 1;
+        n |= n >> 2;
+        n |= n >> 4;
+        n |= n >> 8;
+        n |= n >> 16;
+        if constexpr (sizeof(size_type) > 4) n |= n >> 32;
+        n++;
+        return n;
+    }
+
+    // --- Private Members ---
+
+    // Struct-of-Arrays (SoA) Layout:
+    // This layout is more cache-friendly for probing. The probing loop only needs
+    // to access the small `m_metadata` array. The larger `m_keys` array is only
+    // accessed when a hash match is found.
+    std::unique_ptr<Key[]> m_keys = nullptr;
+    std::unique_ptr<Metadata[]> m_metadata = nullptr;
+    
+    size_type m_size = 0;
+    size_type m_capacity = 0;
+    static constexpr float MAX_LOAD_FACTOR = 0.85f;
+
+    // Use C++20 [[no_unique_address]] for Empty Base Optimization.
+    // If the Hasher or KeyEqual are empty structs (like std::hash),
+    // they will not take up any space in the DirtySet object.
+#if __has_cpp_attribute(no_unique_address)
+    [[no_unique_address]] hasher m_hasher;
+    [[no_unique_address]] key_equal m_key_equal;
+#else
+    hasher m_hasher;
+    key_equal m_key_equal;
+#endif
+};
+
+#endif // DIRTY_SET_HPP

--- a/include/container/dirty_set.hpp
+++ b/include/container/dirty_set.hpp
@@ -3,6 +3,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <cstring>
 #include <functional>
 #include <iterator>
 #include <memory>
@@ -11,6 +12,7 @@
 #include <type_traits>
 #include <utility>
 #include <cassert>
+#include <string>
 
 template <typename Key, typename Hash = std::hash<Key>, typename KeyEqual = std::equal_to<Key>>
 class DirtySet {
@@ -238,7 +240,7 @@ class DirtySet {
 		// Only trigger a rehash if there is a meaningful number of tombstones.
 		// Heuristic: Rehash if the number of occupied slots is greater than the
 		// number of live elements, indicating at least one tombstone exists.
-		if (m_occupied_slots > m_size && m_capacity > 0) {
+		if (m_occupied_slots > (m_size/4) && m_capacity > 0) {
 			// We could also rehash to a smaller capacity if m_size is very low,
 			// but for simplicity, we'll rehash to the current capacity.
 			rehash(m_capacity);
@@ -401,6 +403,7 @@ class DirtySet {
 		}
 
 		m_capacity = new_capacity;
+		std::memset(m_metadata.get(), 0, sizeof(Metadata) * m_capacity);
 		m_size = 0;
 		m_occupied_slots = 0;
 

--- a/include/container/dirty_set.hpp
+++ b/include/container/dirty_set.hpp
@@ -11,394 +11,371 @@
 #include <type_traits>
 #include <utility>
 
-template <
-    typename Key,
-    typename Hash = std::hash<Key>,
-    typename KeyEqual = std::equal_to<Key>
->
+template <typename Key, typename Hash = std::hash<Key>, typename KeyEqual = std::equal_to<Key>>
 class DirtySet {
-private:
-    // --- Internal Data Structures ---
+    private:
+	// --- Internal Data Structures ---
 
-    struct Metadata {
-        // Full hash is stored to speed up rehashes and equality checks.
-        // Probing can first compare hashes (a cheap size_t comparison)
-        // before calling the potentially expensive KeyEqual functor.
-        size_t stored_hash;
+	struct Metadata {
+		// Full hash is stored to speed up rehashes and equality checks.
+		// Probing can first compare hashes (a cheap size_t comparison)
+		// before calling the potentially expensive KeyEqual functor.
+		size_t stored_hash;
 
-        // Probe Sequence Length (PSL). A measure of how far this element is
-        // from its ideal location.
-        // A PSL of 0 indicates an empty/never-used slot.
-        // A PSL of 1 means the element is in its ideal location.
-        // A PSL > 1 means the element was displaced due to a collision.
-        uint32_t psl = 0;
-    };
+		// Probe Sequence Length (PSL). A measure of how far this element is
+		// from its ideal location.
+		// A PSL of 0 indicates an empty/never-used slot.
+		// A PSL of 1 means the element is in its ideal location.
+		// A PSL > 1 means the element was displaced due to a collision.
+		uint32_t psl = 0;
+	};
 
-public:
-    // --- Type Aliases (STL-compliant) ---
-    using key_type = Key;
-    using value_type = Key;
-    using size_type = size_t;
-    using difference_type = ptrdiff_t;
-    using hasher = Hash;
-    using key_equal = KeyEqual;
-    using reference = value_type&;
-    using const_reference = const value_type&;
-    using pointer = value_type*;
-    using const_pointer = const value_type*;
-
-    // --- Forward Iterator Implementation ---
-    template<bool IsConst>
-    class BasicIterator {
     public:
-        using iterator_category = std::forward_iterator_tag;
-        using value_type = Key;
-        using difference_type = ptrdiff_t;
-        using pointer = std::conditional_t<IsConst, const Key*, Key*>;
-        using reference = std::conditional_t<IsConst, const Key&, Key&>;
+	// --- Type Aliases (STL-compliant) ---
+	using key_type = Key;
+	using value_type = Key;
+	using size_type = size_t;
+	using difference_type = ptrdiff_t;
+	using hasher = Hash;
+	using key_equal = KeyEqual;
+	using reference = value_type&;
+	using const_reference = const value_type&;
+	using pointer = value_type*;
+	using const_pointer = const value_type*;
 
-        BasicIterator() noexcept = default;
+	// --- Forward Iterator Implementation ---
+	template <bool IsConst>
+	class BasicIterator {
+	    public:
+		using iterator_category = std::forward_iterator_tag;
+		using value_type = Key;
+		using difference_type = ptrdiff_t;
+		using pointer = std::conditional_t<IsConst, const Key*, Key*>;
+		using reference = std::conditional_t<IsConst, const Key&, Key&>;
 
-        reference operator*() const { return m_keys[m_index]; }
-        pointer operator->() const { return &m_keys[m_index]; }
+		BasicIterator() noexcept = default;
 
-        BasicIterator& operator++() {
-            advance_to_next_full();
-            return *this;
-        }
+		reference operator*() const { return m_keys[m_index]; }
+		pointer operator->() const { return &m_keys[m_index]; }
 
-        BasicIterator operator++(int) {
-            BasicIterator old = *this;
-            ++(*this);
-            return old;
-        }
+		BasicIterator& operator++() {
+			advance_to_next_full();
+			return *this;
+		}
 
-        // Allow conversion from iterator to const_iterator
-        operator BasicIterator<true>() const {
-            return BasicIterator<true>(m_keys, m_metadata, m_index, m_capacity);
-        }
+		BasicIterator operator++(int) {
+			BasicIterator old = *this;
+			++(*this);
+			return old;
+		}
 
-        friend bool operator==(const BasicIterator& lhs, const BasicIterator& rhs) noexcept {
-            return lhs.m_index == rhs.m_index;
-        }
-        friend bool operator!=(const BasicIterator& lhs, const BasicIterator& rhs) noexcept {
-            return !(lhs == rhs);
-        }
+		// Allow conversion from iterator to const_iterator
+		operator BasicIterator<true>() const { return BasicIterator<true>(m_keys, m_metadata, m_index, m_capacity); }
+
+		friend bool operator==(const BasicIterator& lhs, const BasicIterator& rhs) noexcept { return lhs.m_index == rhs.m_index; }
+		friend bool operator!=(const BasicIterator& lhs, const BasicIterator& rhs) noexcept { return !(lhs == rhs); }
+
+	    private:
+		friend class DirtySet;
+		using KeyPtr = std::conditional_t<IsConst, const Key*, Key*>;
+		using MetaPtr = std::conditional_t<IsConst, const Metadata*, Metadata*>;
+
+		BasicIterator(KeyPtr keys, MetaPtr metadata, size_type index, size_type capacity) noexcept
+			: m_keys(keys), m_metadata(metadata), m_index(index), m_capacity(capacity) {}
+
+		void advance_to_next_full() {
+			++m_index;
+			while (m_index < m_capacity && m_metadata[m_index].psl == 0) {
+				++m_index;
+			}
+		}
+
+		KeyPtr m_keys = nullptr;
+		MetaPtr m_metadata = nullptr;
+		size_type m_index = 0;
+		size_type m_capacity = 0;
+	};
+
+	using iterator = BasicIterator<false>;
+	using const_iterator = BasicIterator<true>;
+
+	// --- Constructors, Destructor, Assignment ---
+
+	constexpr DirtySet() noexcept = default;
+
+	~DirtySet() { destroy_keys(); }
+
+	DirtySet(const DirtySet& other) { copy_from(other); }
+
+	DirtySet& operator=(const DirtySet& other) {
+		if (this != &other) {
+			destroy_keys();
+			m_keys.reset();
+			m_metadata.reset();
+			copy_from(other);
+		}
+		return *this;
+	}
+
+	DirtySet(DirtySet&& other) noexcept = default;
+	DirtySet& operator=(DirtySet&& other) noexcept = default;
+
+	// --- Iterators ---
+
+	iterator begin() noexcept {
+		size_type index = 0;
+		while (index < m_capacity && m_metadata[index].psl == 0) {
+			index++;
+		}
+		return iterator(m_keys.get(), m_metadata.get(), index, m_capacity);
+	}
+
+	const_iterator begin() const noexcept {
+		size_type index = 0;
+		while (index < m_capacity && m_metadata[index].psl == 0) {
+			index++;
+		}
+		return const_iterator(m_keys.get(), m_metadata.get(), index, m_capacity);
+	}
+
+	const_iterator cbegin() const noexcept { return begin(); }
+
+	iterator end() noexcept { return iterator(m_keys.get(), m_metadata.get(), m_capacity, m_capacity); }
+
+	const_iterator end() const noexcept { return const_iterator(m_keys.get(), m_metadata.get(), m_capacity, m_capacity); }
+
+	const_iterator cend() const noexcept { return end(); }
+
+	// --- Capacity ---
+
+	[[nodiscard]] bool empty() const noexcept { return m_size == 0; }
+	size_type size() const noexcept { return m_size; }
+
+	void reserve(size_type capacity_hint) {
+		if (capacity_hint == 0)
+			return;
+		size_type new_capacity = next_power_of_two(capacity_hint);
+		if (new_capacity * MAX_LOAD_FACTOR > m_capacity * MAX_LOAD_FACTOR) {
+			rehash(new_capacity);
+		}
+	}
+
+	// --- Modifiers ---
+
+	void clear() noexcept {
+		destroy_keys();
+		// Keep allocated memory for reuse.
+	}
+
+	std::pair<iterator, bool> emplace(Key&& key) {
+		if (m_size + 1 > m_capacity * MAX_LOAD_FACTOR) {
+			rehash(m_capacity > 0 ? m_capacity * 2 : 8);
+		}
+		return find_or_insert_impl(std::move(key));
+	}
+
+	template <typename Predicate>
+	size_type erase_if(Predicate pred) {
+		size_type removed_count = 0;
+		for (size_type i = 0; i < m_capacity; ++i) {
+			if (m_metadata[i].psl != 0 && pred(m_keys[i])) {
+				erase_at(i);
+				removed_count++;
+				// After backward-shifting, the element at 'i' is new
+				// and must be re-evaluated.
+				--i;
+			}
+		}
+		return removed_count;
+	}
 
     private:
-        friend class DirtySet;
-        using KeyPtr = std::conditional_t<IsConst, const Key*, Key*>;
-        using MetaPtr = std::conditional_t<IsConst, const Metadata*, Metadata*>;
+	// --- Private Helper Functions ---
 
-        BasicIterator(KeyPtr keys, MetaPtr metadata, size_type index, size_type capacity) noexcept
-            : m_keys(keys), m_metadata(metadata), m_index(index), m_capacity(capacity) {}
+	void copy_from(const DirtySet& other) {
+		m_capacity = other.m_capacity;
+		m_size = other.m_size;
+		m_hasher = other.m_hasher;
+		m_key_equal = other.m_key_equal;
 
-        void advance_to_next_full() {
-            ++m_index;
-            while (m_index < m_capacity && m_metadata[m_index].psl == 0) {
-                ++m_index;
-            }
-        }
-        
-        KeyPtr m_keys = nullptr;
-        MetaPtr m_metadata = nullptr;
-        size_type m_index = 0;
-        size_type m_capacity = 0;
-    };
+		if (m_capacity > 0) {
+			m_keys = std::make_unique<Key[]>(m_capacity);
+			m_metadata = std::make_unique<Metadata[]>(m_capacity);
 
-    using iterator = BasicIterator<false>;
-    using const_iterator = BasicIterator<true>;
+			for (size_type i = 0; i < m_capacity; ++i) {
+				m_metadata[i] = other.m_metadata[i];
+				if (m_metadata[i].psl != 0) {
+					new (&m_keys[i]) Key(other.m_keys[i]);
+				}
+			}
+		}
+	}
 
-    // --- Constructors, Destructor, Assignment ---
+	std::pair<iterator, bool> find_or_insert_impl(Key&& key) {
+		size_t hash = m_hasher(key);
+		size_type index = hash & (m_capacity - 1);
+		uint32_t current_psl = 1;
 
-    constexpr DirtySet() noexcept = default;
+		while (true) {
+			Metadata& meta = m_metadata[index];
 
-    ~DirtySet() {
-        destroy_keys();
-    }
+			if (meta.psl == 0) { // Found an empty slot. Insert here.
+				new (&m_keys[index]) Key(std::move(key));
+				meta.stored_hash = hash;
+				meta.psl = current_psl;
+				m_size++;
+				return { iterator(m_keys.get(), m_metadata.get(), index, m_capacity), true };
+			}
 
-    DirtySet(const DirtySet& other) {
-        copy_from(other);
-    }
+			// Cheap hash comparison first, then expensive key comparison.
+			if (meta.stored_hash == hash && m_key_equal(m_keys[index], key)) {
+				return { iterator(m_keys.get(), m_metadata.get(), index, m_capacity), false };
+			}
 
-    DirtySet& operator=(const DirtySet& other) {
-        if (this != &other) {
-            destroy_keys();
-            m_keys.reset();
-            m_metadata.reset();
-            copy_from(other);
-        }
-        return *this;
-    }
+			// Robin Hood Hashing: If the element in the current slot is "richer"
+			// (has a smaller PSL) than the element we are trying to insert,
+			// we swap them and continue trying to find a home for the displaced element.
+			if (meta.psl < current_psl) {
+				std::swap(current_psl, meta.psl);
+				std::swap(hash, meta.stored_hash);
+				std::swap(key, m_keys[index]);
+			}
 
-    DirtySet(DirtySet&& other) noexcept = default;
-    DirtySet& operator=(DirtySet&& other) noexcept = default;
+			current_psl++;
+			index = (index + 1) & (m_capacity - 1);
+		}
+	}
 
-    // --- Iterators ---
+	void insert_new(Key&& key, size_t hash) {
+		size_type index = hash & (m_capacity - 1);
+		uint32_t current_psl = 1;
 
-    iterator begin() noexcept {
-        size_type index = 0;
-        while (index < m_capacity && m_metadata[index].psl == 0) {
-            index++;
-        }
-        return iterator(m_keys.get(), m_metadata.get(), index, m_capacity);
-    }
+		while (true) {
+			Metadata& meta = m_metadata[index];
 
-    const_iterator begin() const noexcept {
-        size_type index = 0;
-        while (index < m_capacity && m_metadata[index].psl == 0) {
-            index++;
-        }
-        return const_iterator(m_keys.get(), m_metadata.get(), index, m_capacity);
-    }
-    
-    const_iterator cbegin() const noexcept {
-        return begin();
-    }
+			if (meta.psl == 0) { // Found an empty slot. Insert here.
+				new (&m_keys[index]) Key(std::move(key));
+				meta.stored_hash = hash;
+				meta.psl = current_psl;
+				m_size++;
+				return;
+			}
 
-    iterator end() noexcept {
-        return iterator(m_keys.get(), m_metadata.get(), m_capacity, m_capacity);
-    }
+			if (meta.psl < current_psl) {
+				std::swap(current_psl, meta.psl);
+				size_t temp_hash;
+				std::swap(temp_hash, meta.stored_hash);
+				std::swap(hash, temp_hash);
+				std::swap(key, m_keys[index]);
+			}
 
-    const_iterator end() const noexcept {
-        return const_iterator(m_keys.get(), m_metadata.get(), m_capacity, m_capacity);
-    }
-    
-    const_iterator cend() const noexcept {
-        return end();
-    }
+			current_psl++;
+			index = (index + 1) & (m_capacity - 1);
+		}
+	}
 
-    // --- Capacity ---
+	void erase_at(size_type index) {
+		m_keys[index].~Key(); // Manually destruct the key
+		m_size--;
 
-    [[nodiscard]] bool empty() const noexcept { return m_size == 0; }
-    size_type size() const noexcept { return m_size; }
+		// Backward-shift deletion:
+		// Move subsequent elements in the probe chain back one slot to fill the gap.
+		while (true) {
+			size_type current_index = index;
+			size_type next_index = (index + 1) & (m_capacity - 1);
 
-    void reserve(size_type capacity_hint) {
-        if (capacity_hint == 0) return;
-        size_type new_capacity = next_power_of_two(capacity_hint);
-        if (new_capacity * MAX_LOAD_FACTOR > m_capacity * MAX_LOAD_FACTOR) {
-            rehash(new_capacity);
-        }
-    }
-    
-    // --- Modifiers ---
+			Metadata& next_meta = m_metadata[next_index];
 
-    void clear() noexcept {
-        destroy_keys();
-        // Keep allocated memory for reuse.
-    }
-    
-    std::pair<iterator, bool> emplace(Key&& key) {
-        if (m_size + 1 > m_capacity * MAX_LOAD_FACTOR) {
-            rehash(m_capacity > 0 ? m_capacity * 2 : 8);
-        }
-        return find_or_insert_impl(std::move(key));
-    }
+			// If the next slot is empty or is in its ideal location, the chain is broken.
+			if (next_meta.psl <= 1) {
+				m_metadata[current_index].psl = 0; // Mark current slot as empty.
+				return;
+			}
 
-    template <typename Predicate>
-    size_type erase_if(Predicate pred) {
-        size_type removed_count = 0;
-        for (size_type i = 0; i < m_capacity; ++i) {
-            if (m_metadata[i].psl != 0 && pred(m_keys[i])) {
-                erase_at(i);
-                removed_count++;
-                // After backward-shifting, the element at 'i' is new
-                // and must be re-evaluated.
-                --i;
-            }
-        }
-        return removed_count;
-    }
+			// Move the next element into the current (now empty) slot.
+			new (&m_keys[current_index]) Key(std::move(m_keys[next_index]));
+			m_keys[next_index].~Key();
 
-private:
-    // --- Private Helper Functions ---
+			m_metadata[current_index] = { next_meta.stored_hash, next_meta.psl - 1 };
 
-    void copy_from(const DirtySet& other) {
-        m_capacity = other.m_capacity;
-        m_size = other.m_size;
-        m_hasher = other.m_hasher;
-        m_key_equal = other.m_key_equal;
-        
-        if (m_capacity > 0) {
-            m_keys = std::make_unique<Key[]>(m_capacity);
-            m_metadata = std::make_unique<Metadata[]>(m_capacity);
+			index = next_index;
+		}
+	}
 
-            for (size_type i = 0; i < m_capacity; ++i) {
-                m_metadata[i] = other.m_metadata[i];
-                if (m_metadata[i].psl != 0) {
-                    new (&m_keys[i]) Key(other.m_keys[i]);
-                }
-            }
-        }
-    }
+	void rehash(size_type new_capacity) {
+		// Keep old arrays alive until we are done moving from them.
+		auto old_keys = std::move(m_keys);
+		auto old_metadata = std::move(m_metadata);
+		size_type old_capacity = m_capacity;
 
-    std::pair<iterator, bool> find_or_insert_impl(Key&& key) {
-        const size_t hash = m_hasher(key);
-        size_type index = hash & (m_capacity - 1);
-        uint32_t current_psl = 1;
+		// Allocate and commit new, empty arrays.
+		m_keys = std::make_unique<Key[]>(new_capacity);
+		m_metadata = std::make_unique<Metadata[]>(new_capacity);
+		m_capacity = new_capacity;
+		m_size = 0; // Reset size, will be incremented by insert_new.
 
-        while (true) {
-            Metadata& meta = m_metadata[index];
+		// Iterate old elements and insert them into the new arrays.
+		for (size_type i = 0; i < old_capacity; ++i) {
+			if (old_metadata[i].psl != 0) {
+				// No re-hashing needed! We just use the stored hash.
+				insert_new(std::move(old_keys[i]), old_metadata[i].stored_hash);
+				old_keys[i].~Key(); // Manually destruct the moved-from key.
+			}
+		}
+		// old_keys and old_metadata are destructed here, freeing the old memory.
+	}
 
-            if (meta.psl == 0) { // Found an empty slot. Insert here.
-                new (&m_keys[index]) Key(std::move(key));
-                meta.stored_hash = hash;
-                meta.psl = current_psl;
-                m_size++;
-                return {iterator(m_keys.get(), m_metadata.get(), index, m_capacity), true};
-            }
+	void destroy_keys() noexcept {
+		if (!m_keys)
+			return;
+		for (size_type i = 0; i < m_capacity; ++i) {
+			if (m_metadata[i].psl != 0) {
+				m_keys[i].~Key();
+				m_metadata[i].psl = 0; // Reset metadata
+			}
+		}
+		m_size = 0;
+	}
 
-            // Cheap hash comparison first, then expensive key comparison.
-            if (meta.stored_hash == hash && m_key_equal(m_keys[index], key)) {
-                return {iterator(m_keys.get(), m_metadata.get(), index, m_capacity), false};
-            }
-            
-            // Robin Hood Hashing: If the element in the current slot is "richer"
-            // (has a smaller PSL) than the element we are trying to insert,
-            // we swap them and continue trying to find a home for the displaced element.
-            if (meta.psl < current_psl) {
-                // Swap metadata
-                std::swap(current_psl, meta.psl);
-                size_t temp_hash;
-                std::swap(temp_hash, meta.stored_hash);
-                std::swap(hash, temp_hash);
+	// Finds the smallest power of two that is >= n.
+	static constexpr size_type next_power_of_two(size_type n) {
+		if (n == 0)
+			return 1;
+		// Efficient bit-twiddling algorithm.
+		n--;
+		n |= n >> 1;
+		n |= n >> 2;
+		n |= n >> 4;
+		n |= n >> 8;
+		n |= n >> 16;
+		if constexpr (sizeof(size_type) > 4)
+			n |= n >> 32;
+		n++;
+		return n;
+	}
 
-                // Swap the key we are trying to insert with the one in the slot.
-                std::swap(key, m_keys[index]);
-            }
-            
-            current_psl++;
-            index = (index + 1) & (m_capacity - 1);
-        }
-    }
+	// --- Private Members ---
 
-    void insert_new(Key&& key, size_t hash) {
-        size_type index = hash & (m_capacity - 1);
-        uint32_t current_psl = 1;
+	// Struct-of-Arrays (SoA) Layout:
+	// This layout is more cache-friendly for probing. The probing loop only needs
+	// to access the small `m_metadata` array. The larger `m_keys` array is only
+	// accessed when a hash match is found.
+	std::unique_ptr<Key[]> m_keys = nullptr;
+	std::unique_ptr<Metadata[]> m_metadata = nullptr;
 
-        while (true) {
-            Metadata& meta = m_metadata[index];
+	size_type m_size = 0;
+	size_type m_capacity = 0;
+	static constexpr float MAX_LOAD_FACTOR = 0.85f;
 
-            if (meta.psl == 0) { // Found an empty slot. Insert here.
-                new (&m_keys[index]) Key(std::move(key));
-                meta.stored_hash = hash;
-                meta.psl = current_psl;
-                m_size++;
-                return;
-            }
-
-            if (meta.psl < current_psl) {
-                std::swap(current_psl, meta.psl);
-                size_t temp_hash;
-                std::swap(temp_hash, meta.stored_hash);
-                std::swap(hash, temp_hash);
-                std::swap(key, m_keys[index]);
-            }
-
-            current_psl++;
-            index = (index + 1) & (m_capacity - 1);
-        }
-    }
-
-    void erase_at(size_type index) {
-        m_keys[index].~Key(); // Manually destruct the key
-        m_size--;
-
-        // Backward-shift deletion:
-        // Move subsequent elements in the probe chain back one slot to fill the gap.
-        while (true) {
-            size_type current_index = index;
-            size_type next_index = (index + 1) & (m_capacity - 1);
-            
-            Metadata& next_meta = m_metadata[next_index];
-
-            // If the next slot is empty or is in its ideal location, the chain is broken.
-            if (next_meta.psl <= 1) {
-                m_metadata[current_index].psl = 0; // Mark current slot as empty.
-                return;
-            }
-
-            // Move the next element into the current (now empty) slot.
-            new (&m_keys[current_index]) Key(std::move(m_keys[next_index]));
-            m_keys[next_index].~Key();
-
-            m_metadata[current_index] = {next_meta.stored_hash, next_meta.psl - 1};
-
-            index = next_index;
-        }
-    }
-
-    void rehash(size_type new_capacity) {
-        // Keep old arrays alive until we are done moving from them.
-        auto old_keys = std::move(m_keys);
-        auto old_metadata = std::move(m_metadata);
-        size_type old_capacity = m_capacity;
-
-        // Allocate and commit new, empty arrays.
-        m_keys = std::make_unique<Key[]>(new_capacity);
-        m_metadata = std::make_unique<Metadata[]>(new_capacity);
-        m_capacity = new_capacity;
-        m_size = 0; // Reset size, will be incremented by insert_new.
-
-        // Iterate old elements and insert them into the new arrays.
-        for (size_type i = 0; i < old_capacity; ++i) {
-            if (old_metadata[i].psl != 0) {
-                // No re-hashing needed! We just use the stored hash.
-                insert_new(std::move(old_keys[i]), old_metadata[i].stored_hash);
-                old_keys[i].~Key(); // Manually destruct the moved-from key.
-            }
-        }
-        // old_keys and old_metadata are destructed here, freeing the old memory.
-    }
-
-    void destroy_keys() noexcept {
-        if (!m_keys) return;
-        for (size_type i = 0; i < m_capacity; ++i) {
-            if (m_metadata[i].psl != 0) {
-                m_keys[i].~Key();
-                m_metadata[i].psl = 0; // Reset metadata
-            }
-        }
-        m_size = 0;
-    }
-
-    // Finds the smallest power of two that is >= n.
-    static constexpr size_type next_power_of_two(size_type n) {
-        if (n == 0) return 1;
-        // Efficient bit-twiddling algorithm.
-        n--;
-        n |= n >> 1;
-        n |= n >> 2;
-        n |= n >> 4;
-        n |= n >> 8;
-        n |= n >> 16;
-        if constexpr (sizeof(size_type) > 4) n |= n >> 32;
-        n++;
-        return n;
-    }
-
-    // --- Private Members ---
-
-    // Struct-of-Arrays (SoA) Layout:
-    // This layout is more cache-friendly for probing. The probing loop only needs
-    // to access the small `m_metadata` array. The larger `m_keys` array is only
-    // accessed when a hash match is found.
-    std::unique_ptr<Key[]> m_keys = nullptr;
-    std::unique_ptr<Metadata[]> m_metadata = nullptr;
-    
-    size_type m_size = 0;
-    size_type m_capacity = 0;
-    static constexpr float MAX_LOAD_FACTOR = 0.85f;
-
-    // Use C++20 [[no_unique_address]] for Empty Base Optimization.
-    // If the Hasher or KeyEqual are empty structs (like std::hash),
-    // they will not take up any space in the DirtySet object.
+	// Use C++20 [[no_unique_address]] for Empty Base Optimization.
+	// If the Hasher or KeyEqual are empty structs (like std::hash),
+	// they will not take up any space in the DirtySet object.
 #if __has_cpp_attribute(no_unique_address)
-    [[no_unique_address]] hasher m_hasher;
-    [[no_unique_address]] key_equal m_key_equal;
+	[[no_unique_address]] hasher m_hasher;
+	[[no_unique_address]] key_equal m_key_equal;
 #else
-    hasher m_hasher;
-    key_equal m_key_equal;
+	hasher m_hasher;
+	key_equal m_key_equal;
 #endif
 };
 

--- a/include/container/dirty_set_internal.hpp
+++ b/include/container/dirty_set_internal.hpp
@@ -5,52 +5,49 @@
 
 // Include platform-specific headers for SIMD and other intrinsics
 #if defined(__SSE2__)
-#include <immintrin.h>
+	#include <immintrin.h>
 #endif
 
 #if defined(__GNUC__) || defined(__clang__)
 // For __builtin_ctz on GCC/Clang
 #else
-#include <intrin.h> // For _BitScanForward on MSVC
-#pragma intrinsic(_BitScanForward)
+	#include <intrin.h> // For _BitScanForward on MSVC
+	#pragma intrinsic(_BitScanForward)
 #endif
 
 // --- Portable Prefetch Macro ---
 #if defined(__SSE__)
-    #define DIRTY_SET_PREFETCH(addr) _mm_prefetch(reinterpret_cast<const char*>(addr), _MM_HINT_T0)
+	#define DIRTY_SET_PREFETCH(addr) _mm_prefetch(reinterpret_cast<const char*>(addr), _MM_HINT_T0)
 #else
-    #define DIRTY_SET_PREFETCH(addr) // Expands to nothing on non-SSE platforms
+	#define DIRTY_SET_PREFETCH(addr) // Expands to nothing on non-SSE platforms
 #endif
 
-namespace DirtySetDetail {
+namespace DirtySetDetail
+{
 
 // --- Portable Bit-Scanning Helper ---
 static inline size_t count_trailing_zeros(uint32_t mask) {
-    #if defined(__GNUC__) || defined(__clang__)
-        return __builtin_ctz(mask);
-    #else
-        unsigned long index;
-        _BitScanForward(&index, mask);
-        return index;
-    #endif
+#if defined(__GNUC__) || defined(__clang__)
+	return __builtin_ctz(mask);
+#else
+	unsigned long index;
+	_BitScanForward(&index, mask);
+	return index;
+#endif
 }
 
 // --- BitMask Helper Struct ---
 // A wrapper around a bitmask returned by a group search.
 // Provides a clean, portable way to iterate over set bits.
 struct BitMask {
-    uint32_t mask;
-    BitMask(uint32_t m) : mask(m) {}
+	uint32_t mask;
+	BitMask(uint32_t m) : mask(m) {}
 
-    inline bool any() const { return mask != 0; }
-    
-    inline size_t lowest_set_bit_idx() const {
-        return count_trailing_zeros(mask);
-    }
-    
-    inline void clear_lowest_bit() {
-        mask &= (mask - 1);
-    }
+	inline bool any() const { return mask != 0; }
+
+	inline size_t lowest_set_bit_idx() const { return count_trailing_zeros(mask); }
+
+	inline void clear_lowest_bit() { mask &= (mask - 1); }
 };
 
 // --- SIMD Dispatch via Policy Structs ---
@@ -59,47 +56,43 @@ struct BitMask {
 // The main DirtySet class will select the best available policy at compile time.
 
 struct ProbePolicyScalar {
-    // Represents a group of 16 control bytes using portable C++.
-    struct Group {
-        const int8_t* ctrl;
-        explicit Group(const int8_t* c) : ctrl(c) {}
+	// Represents a group of 16 control bytes using portable C++.
+	struct Group {
+		const int8_t* ctrl;
+		explicit Group(const int8_t* c) : ctrl(c) {}
 
-        inline BitMask match(int8_t h2) const {
-            uint32_t mask = 0;
-            for (size_t i = 0; i < 16; ++i) {
-                if (ctrl[i] == h2) {
-                    mask |= (1 << i);
-                }
-            }
-            return BitMask(mask);
-        }
-        
-        inline BitMask match_empty() const { return match(-128); } // K_EMPTY
-        inline BitMask match_deleted() const { return match(-127); } // K_DELETED
-    };
+		inline BitMask match(int8_t h2) const {
+			uint32_t mask = 0;
+			for (size_t i = 0; i < 16; ++i) {
+				if (ctrl[i] == h2) {
+					mask |= (1 << i);
+				}
+			}
+			return BitMask(mask);
+		}
+
+		inline BitMask match_empty() const { return match(-128); } // K_EMPTY
+		inline BitMask match_deleted() const { return match(-127); } // K_DELETED
+	};
 };
 
 #if defined(__SSE2__)
 struct ProbePolicySSE2 {
-    // Represents a group of 16 control bytes using SSE2 intrinsics.
-    struct Group {
-        __m128i ctrl;
-        explicit Group(const int8_t* c) {
-            ctrl = _mm_loadu_si128(reinterpret_cast<const __m128i*>(c));
-        }
+	// Represents a group of 16 control bytes using SSE2 intrinsics.
+	struct Group {
+		__m128i ctrl;
+		explicit Group(const int8_t* c) { ctrl = _mm_loadu_si128(reinterpret_cast<const __m128i*>(c)); }
 
-        inline BitMask match(int8_t h2) const {
-            return BitMask(_mm_movemask_epi8(_mm_cmpeq_epi8(ctrl, _mm_set1_epi8(h2))));
-        }
+		inline BitMask match(int8_t h2) const { return BitMask(_mm_movemask_epi8(_mm_cmpeq_epi8(ctrl, _mm_set1_epi8(h2)))); }
 
-        inline BitMask match_empty() const {
-            return match(-128); // K_EMPTY
-        }
+		inline BitMask match_empty() const {
+			return match(-128); // K_EMPTY
+		}
 
-        inline BitMask match_deleted() const {
-            return match(-127); // K_DELETED
-        }
-    };
+		inline BitMask match_deleted() const {
+			return match(-127); // K_DELETED
+		}
+	};
 };
 #endif
 

--- a/include/container/dirty_set_internal.hpp
+++ b/include/container/dirty_set_internal.hpp
@@ -1,0 +1,108 @@
+#ifndef DIRTY_SET_INTERNAL_HPP
+#define DIRTY_SET_INTERNAL_HPP
+
+#include <cstdint>
+
+// Include platform-specific headers for SIMD and other intrinsics
+#if defined(__SSE2__)
+#include <immintrin.h>
+#endif
+
+#if defined(__GNUC__) || defined(__clang__)
+// For __builtin_ctz on GCC/Clang
+#else
+#include <intrin.h> // For _BitScanForward on MSVC
+#pragma intrinsic(_BitScanForward)
+#endif
+
+// --- Portable Prefetch Macro ---
+#if defined(__SSE__)
+    #define DIRTY_SET_PREFETCH(addr) _mm_prefetch(reinterpret_cast<const char*>(addr), _MM_HINT_T0)
+#else
+    #define DIRTY_SET_PREFETCH(addr) // Expands to nothing on non-SSE platforms
+#endif
+
+namespace DirtySetDetail {
+
+// --- Portable Bit-Scanning Helper ---
+static inline size_t count_trailing_zeros(uint32_t mask) {
+    #if defined(__GNUC__) || defined(__clang__)
+        return __builtin_ctz(mask);
+    #else
+        unsigned long index;
+        _BitScanForward(&index, mask);
+        return index;
+    #endif
+}
+
+// --- BitMask Helper Struct ---
+// A wrapper around a bitmask returned by a group search.
+// Provides a clean, portable way to iterate over set bits.
+struct BitMask {
+    uint32_t mask;
+    BitMask(uint32_t m) : mask(m) {}
+
+    inline bool any() const { return mask != 0; }
+    
+    inline size_t lowest_set_bit_idx() const {
+        return count_trailing_zeros(mask);
+    }
+    
+    inline void clear_lowest_bit() {
+        mask &= (mask - 1);
+    }
+};
+
+// --- SIMD Dispatch via Policy Structs ---
+// This is the core of the portability and extensibility refactoring.
+// We define a policy for each implementation (SSE2, Scalar, and future AVX2/NEON).
+// The main DirtySet class will select the best available policy at compile time.
+
+struct ProbePolicyScalar {
+    // Represents a group of 16 control bytes using portable C++.
+    struct Group {
+        const int8_t* ctrl;
+        explicit Group(const int8_t* c) : ctrl(c) {}
+
+        inline BitMask match(int8_t h2) const {
+            uint32_t mask = 0;
+            for (size_t i = 0; i < 16; ++i) {
+                if (ctrl[i] == h2) {
+                    mask |= (1 << i);
+                }
+            }
+            return BitMask(mask);
+        }
+        
+        inline BitMask match_empty() const { return match(-128); } // K_EMPTY
+        inline BitMask match_deleted() const { return match(-127); } // K_DELETED
+    };
+};
+
+#if defined(__SSE2__)
+struct ProbePolicySSE2 {
+    // Represents a group of 16 control bytes using SSE2 intrinsics.
+    struct Group {
+        __m128i ctrl;
+        explicit Group(const int8_t* c) {
+            ctrl = _mm_loadu_si128(reinterpret_cast<const __m128i*>(c));
+        }
+
+        inline BitMask match(int8_t h2) const {
+            return BitMask(_mm_movemask_epi8(_mm_cmpeq_epi8(ctrl, _mm_set1_epi8(h2))));
+        }
+
+        inline BitMask match_empty() const {
+            return match(-128); // K_EMPTY
+        }
+
+        inline BitMask match_deleted() const {
+            return match(-127); // K_DELETED
+        }
+    };
+};
+#endif
+
+} // namespace DirtySetDetail
+
+#endif // DIRTY_SET_INTERNAL_HPP

--- a/include/container/packed_pauli_term.inl
+++ b/include/container/packed_pauli_term.inl
@@ -294,6 +294,7 @@ class NonOwningPauliTermPacked {
 	void fast_copy_content(NonOwningPauliTermPacked const& nopt) {
 		assert(&nopt.ptc.get() == &ptc.get());
 		set_coefficient(nopt.coefficient());
+		_set_dirty(nopt._is_dirty());
 		ptc.get().copy_fast(nopt.idx, idx);
 	}
 	/** @} */

--- a/include/container/packed_pauli_term.inl
+++ b/include/container/packed_pauli_term.inl
@@ -177,7 +177,9 @@ class NonOwningPauliTermPacked {
 
 	bool _is_dirty() const { return ptc.get().is_dirty(idx); }
 
-	void _set_dirty(bool v) { return ptc.get().set_dirty(idx, v); }
+	void _set_dirty(bool v) { ptc.get().set_dirty(idx, v); }
+
+	void _add_dirty(bool v) { _set_dirty(_is_dirty() || v); }
 
 	/** @name Accessors and Mutators
 	 * @{
@@ -309,14 +311,14 @@ class NonOwningPauliTermPacked {
 		auto p = pb;
 		set_coefficient(coefficient() * p.apply_clifford(g));
 		set_pauli(qubit, p);
-		_set_dirty(pb != p);
+		_add_dirty(pb != p);
 	}
 	void apply_unital_noise(UnitalNoise n, unsigned qubit, T p) {
 		assert(qubit < size());
-		const auto bpauli = get_pauli(qubit);
-		auto pauli = bpauli;
+		const auto pauli = get_pauli(qubit);
+		// auto pauli = bpauli;
 		set_coefficient(coefficient() * pauli.apply_unital_noise(n, p));
-		_set_dirty(bpauli != pauli);
+		//_add_dirty(bpauli != pauli);
 	}
 	void apply_cx(unsigned control, unsigned target) {
 		assert(control != target && "cx can't use same control and target");
@@ -328,7 +330,7 @@ class NonOwningPauliTermPacked {
 		set_coefficient(coefficient() * pctrl.apply_cx(ptarg));
 		set_pauli(control, pctrl);
 		set_pauli(target, ptarg);
-		_set_dirty(pctrl != bpctrl || ptarg != bptarg);
+		_add_dirty(pctrl != bpctrl || ptarg != bptarg);
 	}
 	void apply_rz(unsigned qubit, T theta, NonOwningPauliTermPacked& output) {
 		assert(qubit < size());
@@ -347,7 +349,7 @@ class NonOwningPauliTermPacked {
 			output.set_pauli(qubit, p_x);
 			output.set_coefficient(output.coefficient() * sin_theta);
 		}
-		output._set_dirty(true);
+		output._add_dirty(true);
 	}
 	void apply_amplitude_damping_xy([[maybe_unused]] unsigned qubit, T p) {
 		assert(qubit < size());
@@ -360,7 +362,7 @@ class NonOwningPauliTermPacked {
 		output.set_coefficient(output.coefficient() * p);
 		output.set_pauli(qubit, p_i);
 		set_coefficient(coefficient() * (1 - p));
-		output._set_dirty(true);
+		output._add_dirty(true);
 	}
 	/** @} */
 

--- a/include/container/packed_pauli_term.inl
+++ b/include/container/packed_pauli_term.inl
@@ -111,6 +111,11 @@ class ReadOnlyNonOwningPauliTermPacked {
 		return (&ptc.get() == &oth.ptc.get()) ? ptc.get().fast_equal_bitstring(idx, oth.idx) : slow_equal_bitstring(oth);
 	}
 
+	bool fast_equal_bitstring(ReadOnlyNonOwningPauliTermPacked const& oth) const {
+		assert(&ptc.get() == &oth.ptc.get());
+		return ptc.get().fast_equal_bitstring(idx, oth.idx);
+	}
+
 	/**
 	 * @brief Performs an element-by-element comparison of the Pauli string.
 	 * @return `true` if the Pauli strings are identical.
@@ -244,7 +249,7 @@ class NonOwningPauliTermPacked {
 	}
 	friend bool operator==(NonOwningPauliTermPacked const& lhs, PauliTerm<T> const& rhs) { return rhs == lhs; }
 	bool equal_bitstring(NonOwningPauliTermPacked const& oth) const {
-		return (&ptc.get() == &oth.ptc.get()) ? ptc.get().fast_equal_bitstring(idx, oth.idx) : slow_equal_bitstring(oth);
+		return (&ptc.get() == &oth.ptc.get()) ? fast_equal_bitstring(oth) : slow_equal_bitstring(oth);
 	}
 	bool slow_equal_bitstring(NonOwningPauliTermPacked const& oth) const {
 		if (oth.size() != size())
@@ -255,6 +260,11 @@ class NonOwningPauliTermPacked {
 			}
 		}
 		return true;
+	}
+
+	bool fast_equal_bitstring(NonOwningPauliTermPacked const& oth) const {
+		assert(&ptc.get() == &oth.ptc.get());
+		return ptc.get().fast_equal_bitstring(idx, oth.idx);
 	}
 	/** @} */
 

--- a/include/container/packed_pauli_term.inl
+++ b/include/container/packed_pauli_term.inl
@@ -7,8 +7,6 @@
  * parent container, often using highly optimized "fast" methods that operate
  * directly on the packed bit representation.
  */
-#include <cstddef>
-#include <unistd.h>
 class ReadOnlyNonOwningPauliTermPacked {
     protected:
 	/// @brief A const reference to the parent container that owns the data.
@@ -79,8 +77,6 @@ class ReadOnlyNonOwningPauliTermPacked {
 	 * @note This is a high-performance operation that delegates to the container's `fast_phash` method.
 	 */
 	std::size_t phash() const noexcept { return ptc.get().fast_phash(idx); }
-	
-	std::size_t xxhash() const noexcept { return ptc.get().fast_phash_xxhash3(idx); }
 
 	/** @name Comparison
 	 * @{
@@ -241,8 +237,6 @@ class NonOwningPauliTermPacked {
 	 * @note This is a high-performance operation that delegates to the container's `fast_phash` method.
 	 */
 	std::size_t phash() const noexcept { return ptc.get().fast_phash(idx); }
-
-	std::size_t xxhash() const noexcept { return ptc.get().fast_phash_xxh3(idx); }
 
 	/** @name Comparison
 	 * @{

--- a/include/container/packed_pauli_term.inl
+++ b/include/container/packed_pauli_term.inl
@@ -7,6 +7,8 @@
  * parent container, often using highly optimized "fast" methods that operate
  * directly on the packed bit representation.
  */
+#include <cstddef>
+#include <unistd.h>
 class ReadOnlyNonOwningPauliTermPacked {
     protected:
 	/// @brief A const reference to the parent container that owns the data.
@@ -77,6 +79,8 @@ class ReadOnlyNonOwningPauliTermPacked {
 	 * @note This is a high-performance operation that delegates to the container's `fast_phash` method.
 	 */
 	std::size_t phash() const noexcept { return ptc.get().fast_phash(idx); }
+	
+	std::size_t xxhash() const noexcept { return ptc.get().fast_phash_xxhash3(idx); }
 
 	/** @name Comparison
 	 * @{
@@ -237,6 +241,8 @@ class NonOwningPauliTermPacked {
 	 * @note This is a high-performance operation that delegates to the container's `fast_phash` method.
 	 */
 	std::size_t phash() const noexcept { return ptc.get().fast_phash(idx); }
+
+	std::size_t xxhash() const noexcept { return ptc.get().fast_phash_xxh3(idx); }
 
 	/** @name Comparison
 	 * @{

--- a/include/merge.hpp
+++ b/include/merge.hpp
@@ -81,7 +81,11 @@ class Merger {
 		// hset.
 		// hset.clear();
 		//[[maybe_unused]] auto removed = std::erase_if(hset, [](auto const& nopt) { return nopt._is_dirty(); });
-		hset.reserve(paulis_.nb_terms());
+		if (hset.capacity() < paulis_.nb_terms()) {
+			hset.reserve(paulis_.nb_terms());
+		} else {
+			hset.compact();
+		}
 		debug("after erase: ", paulis_);
 	}
 

--- a/include/merge.hpp
+++ b/include/merge.hpp
@@ -17,9 +17,6 @@
 
 #include <algorithm>
 #include <type_traits>
-#include <tsl/robin_set.h>
-#include <unistd.h>
-#include <unordered_set>
 
 template <typename T>
 struct FastPauliStringEqual {

--- a/include/merge.hpp
+++ b/include/merge.hpp
@@ -58,11 +58,16 @@ struct FastPauliStringEqual {
 };
 
 template <typename T>
+struct FastPauliStringHash {
+	bool operator()(T const& pt) const { return pt.xxhash(); }
+};
+
+template <typename T>
 class Merger {
     private:
 	using PTC_t = PauliTermContainer<T>;
 	using nopt_t = std::remove_cvref_t<PTC_t>::non_owning_t;
-	DirtySet<nopt_t, GenericPauliTermHash<nopt_t>, FastPauliStringEqual<nopt_t>> hset;
+	DirtySet<nopt_t, FastPauliStringHash<nopt_t>, FastPauliStringEqual<nopt_t>> hset;
 	// std::unordered_set<nopt_t, GenericPauliTermHash<nopt_t>, GenericPauliStringEqual<nopt_t>> hset;
 	// tsl::robin_set<nopt_t, GenericPauliTermHash<nopt_t>, GenericPauliStringEqual<nopt_t>, std::allocator<nopt_t>, true> hset;
 
@@ -86,7 +91,7 @@ class Merger {
 
 		for (std::size_t i = 0; i < paulis_.nb_terms(); ++i) {
 			auto nopt = paulis_[i];
-			assert((debug_find(nopt, hset, paulis_), true));
+			//assert((debug_find(nopt, hset, paulis_), true));
 			if (nopt._is_dirty()) {
 				auto c = nopt.coefficient();
 
@@ -117,7 +122,7 @@ class Merger {
 		}*/
 		// hset.erase_if([](auto const& nopt) { return true; });
 		hset.erase_if([](auto const& nopt) { return nopt._is_dirty(); });
-		assert(!std::any_of(hset.begin(), hset.end(), [](auto const& nopt) { return nopt._is_dirty(); }));
+		//assert(!std::any_of(hset.begin(), hset.end(), [](auto const& nopt) { return nopt._is_dirty(); }));
 		// hset.
 		// hset.clear();
 		//[[maybe_unused]] auto removed = std::erase_if(hset, [](auto const& nopt) { return nopt._is_dirty(); });
@@ -128,8 +133,8 @@ class Merger {
 		}
 		debug("after erase: ", paulis_);
 
-		assert(no_duplicates(hset));
-		assert(!std::any_of(hset.begin(), hset.end(), [](auto const& nopt) { return nopt._is_dirty(); }));
+		//assert(no_duplicates(hset));
+		//assert(!std::any_of(hset.begin(), hset.end(), [](auto const& nopt) { return nopt._is_dirty(); }));
 	}
 
 	void after_merge(PTC_t& paulis_) {

--- a/include/merge.hpp
+++ b/include/merge.hpp
@@ -62,7 +62,6 @@ struct FastPauliStringHash {
 	bool operator()(T const& pt) const noexcept { return pt.xxhash(); }
 };
 
-
 template <typename T>
 class Merger {
     private:
@@ -92,19 +91,19 @@ class Merger {
 
 		for (std::size_t i = 0; i < paulis_.nb_terms(); ++i) {
 			auto nopt = paulis_[i];
-			assert((debug_find(nopt, hset, paulis_), true));
-			//if (nopt._is_dirty()) {
-				auto c = nopt.coefficient();
+			// assert((debug_find(nopt, hset, paulis_), true));
+			// if (nopt._is_dirty()) {
+			auto c = nopt.coefficient();
 
-				auto [it, is_new] = hset.emplace(std::move(nopt));
-				if (!is_new) { // A term with this Pauli string already exists in the set.
-					// Add the current coefficient to the existing term.
-					it->add_coeff(c);
-					// Remove the current (duplicate) term from the container.
-					paulis_.remove_pauliterm(i);
-					// Decrement index to re-evaluate the new element at the current position.
-					--i;
-				}
+			auto [it, is_new] = hset.emplace(std::move(nopt));
+			if (!is_new) { // A term with this Pauli string already exists in the set.
+				// Add the current coefficient to the existing term.
+				it->add_coeff(c);
+				// Remove the current (duplicate) term from the container.
+				paulis_.remove_pauliterm(i);
+				// Decrement index to re-evaluate the new element at the current position.
+				--i;
+			}
 			//}
 		}
 
@@ -112,7 +111,7 @@ class Merger {
 	}
 
 	void prepare_merge(PTC_t const& paulis_) {
-		//std::cout << "\nBefore merge: #pt=" << paulis_.nb_terms() << "  |  #hset=" << hset.size() << "\n";
+		// std::cout << "\nBefore merge: #pt=" << paulis_.nb_terms() << "  |  #hset=" << hset.size() << "\n";
 		debug("before erase: ", paulis_);
 
 		// hset.rehash(hset.size());
@@ -122,9 +121,10 @@ class Merger {
 				// hset.erase(it);
 			}
 		}*/
-		hset.erase_if([](auto const& nopt) { return true; });
-		//hset.erase_if([](auto const& nopt) { return nopt._is_dirty(); });
-		assert(!std::any_of(hset.begin(), hset.end(), [](auto const& nopt) { return nopt._is_dirty(); }));
+		hset.clear();
+		//hset.erase_if([](auto const& nopt) { return true; });
+		// hset.erase_if([](auto const& nopt) { return nopt._is_dirty(); });
+		// assert(!std::any_of(hset.begin(), hset.end(), [](auto const& nopt) { return nopt._is_dirty(); }));
 		// hset.
 		// hset.clear();
 		//[[maybe_unused]] auto removed = std::erase_if(hset, [](auto const& nopt) { return nopt._is_dirty(); });
@@ -135,18 +135,18 @@ class Merger {
 		}
 		debug("after erase: ", paulis_);
 
-		assert(no_duplicates(hset));
-		assert(!std::any_of(hset.begin(), hset.end(), [](auto const& nopt) { return nopt._is_dirty(); }));
-		//std::cout << "After erase: #pt=" << paulis_.nb_terms() << "  |  #hset=" << hset.size() << "\n";
+		// assert(no_duplicates(hset));
+		// assert(!std::any_of(hset.begin(), hset.end(), [](auto const& nopt) { return nopt._is_dirty(); }));
+		// std::cout << "After erase: #pt=" << paulis_.nb_terms() << "  |  #hset=" << hset.size() << "\n";
 	}
 
 	void after_merge(PTC_t& paulis_) {
-		//std::cout << "After merge: #pt=" << paulis_.nb_terms() << "  |  #hset=" << hset.size() << "\n";
+		// std::cout << "After merge: #pt=" << paulis_.nb_terms() << "  |  #hset=" << hset.size() << "\n";
 		for (std::size_t i = 0; i < paulis_.nb_terms(); ++i) {
 			paulis_[i]._set_dirty(false);
 		}
 		debug("after merge: ", paulis_);
-		assert(no_duplicates(paulis_));
+		// assert(no_duplicates(paulis_));
 	}
 
 	void debug_find(nopt_t nopt, decltype(hset)& hset, PTC_t const& paulis_) {
@@ -164,16 +164,16 @@ class Merger {
 
 	void debug(std::string const& str, PTC_t const& paulis_) {
 		return;
-		//std::cout << str << "\nhset:\n";
+		// std::cout << str << "\nhset:\n";
 		for (auto it = hset.begin(); it != hset.end(); ++it) {
-			//std::cout << *it << " [dirty=" << (it->_is_dirty() ? "1" : "0") << "]\n";
+			// std::cout << *it << " [dirty=" << (it->_is_dirty() ? "1" : "0") << "]\n";
 		}
-		//std::cout << "\npaulis_:\n";
+		// std::cout << "\npaulis_:\n";
 		for (std::size_t i = 0; i < paulis_.nb_terms(); ++i) {
 			auto nopt = paulis_[i];
-			//std::cout << nopt << "[dirty=" << (nopt._is_dirty() ? "1" : "0") << "]\n";
+			// std::cout << nopt << "[dirty=" << (nopt._is_dirty() ? "1" : "0") << "]\n";
 		}
-		//std::cout << "\n";
+		// std::cout << "\n";
 	}
 };
 

--- a/include/merge.hpp
+++ b/include/merge.hpp
@@ -53,11 +53,16 @@ bool no_duplicates(PauliTermContainer<T>& paulis_) {
 }
 
 template <typename T>
+struct FastPauliStringEqual {
+	bool operator()(T const& lhs, T const& rhs) const { return lhs.fast_equal_bitstring(rhs); }
+};
+
+template <typename T>
 class Merger {
     private:
 	using PTC_t = PauliTermContainer<T>;
 	using nopt_t = std::remove_cvref_t<PTC_t>::non_owning_t;
-	DirtySet<nopt_t, GenericPauliTermHash<nopt_t>, GenericPauliStringEqual<nopt_t>> hset;
+	DirtySet<nopt_t, GenericPauliTermHash<nopt_t>, FastPauliStringEqual<nopt_t>> hset;
 	// std::unordered_set<nopt_t, GenericPauliTermHash<nopt_t>, GenericPauliStringEqual<nopt_t>> hset;
 	// tsl::robin_set<nopt_t, GenericPauliTermHash<nopt_t>, GenericPauliStringEqual<nopt_t>, std::allocator<nopt_t>, true> hset;
 

--- a/include/observable.hpp
+++ b/include/observable.hpp
@@ -49,8 +49,7 @@ class Observable {
 	 * @param coeff The coefficient of this Pauli term.
 	 * @snippet tests/snippets/observable.cpp observable_from_string
 	 */
-	Observable(std::string_view pauli_string,
-		   typename std::enable_if_t<std::is_constructible_v<T, coeff_t>, T> coeff = T{ 1 })
+	Observable(std::string_view pauli_string, typename std::enable_if_t<std::is_constructible_v<T, coeff_t>, T> coeff = T{ 1 })
 		: paulis_{ PauliTerm<T>(pauli_string, coeff) } {
 		check_invariant();
 	}
@@ -60,9 +59,7 @@ class Observable {
 	 * @param pauli_string_list An initializer list of Pauli strings. Each will have a coefficient of 1.
 	 * @snippet tests/snippets/observable.cpp observable_from_string_list
 	 */
-	Observable(std::initializer_list<std::string_view> pauli_string_list) : paulis_{ pauli_string_list } {
-		check_invariant();
-	}
+	Observable(std::initializer_list<std::string_view> pauli_string_list) : paulis_{ pauli_string_list } { check_invariant(); }
 
 	/**
 	 * @brief Constructs an observable from a list of PauliTerm objects.
@@ -261,7 +258,7 @@ class Observable {
 	 * It calls a high-performance, in-place merging algorithm.
 	 */
 	std::size_t merge() {
-		merge_inplace_noalloc(paulis_);
+		merger_(paulis_);
 		return paulis_.nb_terms();
 	}
 
@@ -301,6 +298,7 @@ class Observable {
 
     private:
 	PauliTermContainer<T> paulis_;
+	Merger<T> merger_;
 
 	void check_invariant() const {
 		if (paulis_.nb_terms() == 0) {

--- a/include/pauli_term_container.hpp
+++ b/include/pauli_term_container.hpp
@@ -138,6 +138,7 @@ class PauliTermContainer {
 
 	bool is_dirty(std::size_t idx) const {
 		assert(idx < nb_terms());
+		//return true;
 		return dirty[idx];
 	}
 

--- a/include/pauli_term_container.hpp
+++ b/include/pauli_term_container.hpp
@@ -50,7 +50,6 @@ class PauliTermContainer {
 	 */
 	std::vector<Underlying> raw_bits; ///< Contiguous memory for the bit-packed Pauli strings.
 	std::vector<T> raw_coefficients; ///< Vector of coefficients, one for each Pauli term.
-	std::vector<bool> dirty;
 	std::size_t qubits; ///< The number of qubits for all terms in the container.
 	/** @} */
 
@@ -139,17 +138,6 @@ class PauliTermContainer {
 		set_opti();
 	}
 
-	bool is_dirty(std::size_t idx) const {
-		assert(idx < nb_terms());
-		// return true;
-		return dirty[idx];
-	}
-
-	void set_dirty(std::size_t idx, bool v) {
-		assert(idx < nb_terms());
-		dirty[idx] = v;
-	}
-
     public:
 	/** @name Constructors
 	 * @{
@@ -166,7 +154,6 @@ class PauliTermContainer {
 		set_qubits(nb_qubits);
 		resize_paulis_terms(DEFAULT_ALLOC);
 		raw_coefficients.reserve(DEFAULT_ALLOC);
-		dirty.reserve(DEFAULT_ALLOC);
 	}
 
 	/**
@@ -185,7 +172,7 @@ class PauliTermContainer {
 
 		resize_paulis_terms(std::max(DEFAULT_ALLOC, size));
 		raw_coefficients.reserve(size);
-		dirty.resize(size, true);
+
 		std::size_t i = 0;
 		for (; bcopy != end; ++bcopy, ++i) {
 			raw_coefficients.push_back(bcopy->coefficient());
@@ -364,7 +351,6 @@ class PauliTermContainer {
 	[[nodiscard]] NonOwningPauliTermPacked create_pauliterm() {
 		resize_paulis_terms(nb_terms() + 1);
 		raw_coefficients.push_back(T{ 0 });
-		dirty.push_back(true);
 		return { *this, nb_terms() - 1 };
 	}
 
@@ -377,7 +363,6 @@ class PauliTermContainer {
 		assert(idx < nb_terms());
 		auto np = create_pauliterm();
 		np.fast_copy_content((*this)[idx]);
-		np._set_dirty(true);
 		return np;
 	}
 
@@ -390,12 +375,10 @@ class PauliTermContainer {
 	void remove_pauliterm(std::size_t idx) {
 		assert(idx < nb_terms());
 		raw_coefficients[idx] = raw_coefficients.back();
-		dirty[idx] = dirty.back();
 		auto last = (*this)[nb_terms() - 1];
 		auto to_del = (*this)[idx];
 		to_del.fast_copy_content(last);
 		raw_coefficients.pop_back();
-		dirty.pop_back();
 	}
 /** @} */
 

--- a/include/pauli_term_container.hpp
+++ b/include/pauli_term_container.hpp
@@ -24,6 +24,7 @@
 #include <algorithm>
 #include <cassert>
 #include <cstddef>
+#include <cstring>
 #include <iterator>
 #include <string_view>
 #include <vector>
@@ -300,9 +301,8 @@ class PauliTermContainer {
 		assert(index_lhs < nb_terms());
 		assert(index_rhs < nb_terms());
 		const std::size_t lhs_start = index_lhs * nb_underlying_per_pt;
-		const std::size_t lhs_end = lhs_start + nb_underlying_per_pt;
 		const std::size_t rhs_start = index_rhs * nb_underlying_per_pt;
-		return std::equal(raw_bits.begin() + lhs_start, raw_bits.begin() + lhs_end, raw_bits.begin() + rhs_start);
+		return std::memcmp(raw_bits.data() + lhs_start, raw_bits.data() + rhs_start, nb_underlying_per_pt) == 0;
 	}
 
 	/**

--- a/include/pauli_term_container.hpp
+++ b/include/pauli_term_container.hpp
@@ -283,6 +283,8 @@ class PauliTermContainer {
 	std::size_t fast_phash(std::size_t index) const noexcept {
 		assert(index < nb_terms());
 		const auto start_idx = index * nb_underlying_per_pt;
+		return XXH3_64bits(raw_bits.data() + start_idx, sizeof(Underlying) * nb_underlying_per_pt);
+		/*
 		static constexpr std::size_t shift_num = sizeof(Underlying) * 8;
 		static constexpr std::size_t max_shift = sizeof(std::size_t) * 8;
 		std::size_t ret = 0;
@@ -290,13 +292,7 @@ class PauliTermContainer {
 			const std::size_t uv = raw_bits[start_idx + i];
 			ret ^= uv << ((i * shift_num) % max_shift);
 		}
-		return ret;
-	}
-
-	std::size_t fast_phash_xxh3(std::size_t index) const noexcept {
-		assert(index < nb_terms());
-		const auto start_idx = index * nb_underlying_per_pt;
-		return XXH3_64bits(raw_bits.data() + start_idx, sizeof(Underlying) * nb_underlying_per_pt);
+		return ret;*/
 	}
 
 	/**

--- a/include/pauli_term_container.hpp
+++ b/include/pauli_term_container.hpp
@@ -29,6 +29,8 @@
 #include <string_view>
 #include <vector>
 
+#include <xxhash.h>
+
 /**
  * @brief A specialized container for storing Pauli terms in a memory-packed format.
  * @tparam T The numeric type for the coefficients (e.g., float, double).
@@ -139,7 +141,7 @@ class PauliTermContainer {
 
 	bool is_dirty(std::size_t idx) const {
 		assert(idx < nb_terms());
-		//return true;
+		// return true;
 		return dirty[idx];
 	}
 
@@ -289,6 +291,12 @@ class PauliTermContainer {
 			ret ^= uv << ((i * shift_num) % max_shift);
 		}
 		return ret;
+	}
+
+	std::size_t fast_phash_xxh3(std::size_t index) const noexcept {
+		assert(index < nb_terms());
+		const auto start_idx = index * nb_underlying_per_pt;
+		return XXH3_64bits(raw_bits.data() + start_idx, sizeof(Underlying) * nb_underlying_per_pt);
 	}
 
 	/**

--- a/tests/dirty_set.cpp
+++ b/tests/dirty_set.cpp
@@ -1,0 +1,327 @@
+#include "container/dirty_set.hpp"
+#include <gtest/gtest.h>
+#include <vector>
+#include <numeric>
+#include <algorithm>
+
+// --- A "Spy" Key class to track object lifetime ---
+// This class allows us to verify that the container is correctly constructing,
+// destructing, moving, and copying elements without leaks or double-frees.
+struct TrackedInt {
+	// Static counters to track lifetime events across all instances
+	static size_t constructions;
+	static size_t destructions;
+	static size_t copies;
+	static size_t moves;
+
+	int id;
+	bool dirty;
+
+	// Helper to reset counters before each test
+	static void reset_counts() {
+		constructions = 0;
+		destructions = 0;
+		copies = 0;
+		moves = 0;
+	}
+
+	// Main constructor
+	explicit TrackedInt(int val, bool is_dirty = false) : id(val), dirty(is_dirty) { constructions++; }
+
+	// Copy constructor
+	TrackedInt(const TrackedInt& other) : id(other.id), dirty(other.dirty) {
+		constructions++;
+		copies++;
+	}
+
+	// Move constructor (invalidates the source)
+	TrackedInt(TrackedInt&& other) noexcept : id(other.id), dirty(other.dirty) {
+		other.id = -1; // Mark as moved-from
+		constructions++;
+		moves++;
+	}
+
+	// Copy assignment
+	TrackedInt& operator=(const TrackedInt& other) {
+		id = other.id;
+		dirty = other.dirty;
+		copies++;
+		return *this;
+	}
+
+	// Move assignment
+	TrackedInt& operator=(TrackedInt&& other) noexcept {
+		id = other.id;
+		dirty = other.dirty;
+		other.id = -1;
+		moves++;
+		return *this;
+	}
+
+	// Destructor (only counts if the object is valid)
+	~TrackedInt() {
+		if (id != -1) {
+			destructions++;
+		}
+	}
+
+	// Equality is based on ID only
+	bool operator==(const TrackedInt& other) const { return id == other.id; }
+};
+
+// Initialize static counters
+size_t TrackedInt::constructions = 0;
+size_t TrackedInt::destructions = 0;
+size_t TrackedInt::copies = 0;
+size_t TrackedInt::moves = 0;
+
+// Custom hasher for TrackedInt
+struct TrackedIntHash {
+	size_t operator()(const TrackedInt& ti) const { return std::hash<int>()(ti.id); }
+};
+
+// --- Test Fixture ---
+// Creates a fresh DirtySet and resets counters for each test
+class DirtySetTest : public ::testing::Test {
+    protected:
+	void SetUp() override { TrackedInt::reset_counts(); }
+
+	void TearDown() override {
+		set.clear();
+		// The check is removed from here. We will add more specific checks in each test.
+	}
+	DirtySet<TrackedInt, TrackedIntHash> set;
+};
+
+// --- Unit Tests ---
+
+TEST_F(DirtySetTest, DefaultConstruction) {
+	EXPECT_EQ(set.size(), 0);
+	EXPECT_TRUE(set.empty());
+	EXPECT_EQ(set.begin(), set.end());
+}
+
+TEST_F(DirtySetTest, EmplaceNewElement) {
+	auto [it, inserted] = set.emplace(TrackedInt(10));
+
+	EXPECT_TRUE(inserted);
+	EXPECT_EQ(set.size(), 1);
+	ASSERT_NE(it, set.end());
+	EXPECT_EQ(it->id, 10);
+}
+
+TEST_F(DirtySetTest, EmplaceExistingElement) {
+	set.emplace(TrackedInt(10)); // Setup
+	TrackedInt::reset_counts(); // Reset after setup
+
+	auto [it, inserted] = set.emplace(TrackedInt(10));
+
+	EXPECT_FALSE(inserted);
+	EXPECT_EQ(set.size(), 1);
+	ASSERT_NE(it, set.end());
+	EXPECT_EQ(it->id, 10);
+}
+TEST_F(DirtySetTest, EraseIfSimple) {
+	set.emplace(TrackedInt(10));
+	set.emplace(TrackedInt(20, true)); // Mark this one as dirty
+	set.emplace(TrackedInt(30));
+	EXPECT_EQ(set.size(), 3);
+
+	TrackedInt::reset_counts();
+
+	size_t erased_count = set.erase_if([](const TrackedInt& key) { return key.dirty; });
+
+	EXPECT_EQ(erased_count, 1);
+	EXPECT_EQ(set.size(), 2);
+}
+
+TEST_F(DirtySetTest, EraseIfMultiple) {
+	set.emplace(TrackedInt(10, true));
+	set.emplace(TrackedInt(20));
+	set.emplace(TrackedInt(30, true));
+	set.emplace(TrackedInt(40));
+	EXPECT_EQ(set.size(), 4);
+
+	TrackedInt::reset_counts();
+
+	size_t erased_count = set.erase_if([](const TrackedInt& key) { return key.dirty; });
+
+	EXPECT_EQ(erased_count, 2);
+	EXPECT_EQ(set.size(), 2);
+}
+
+TEST_F(DirtySetTest, EraseIfNone) {
+	set.emplace(TrackedInt(10));
+	set.emplace(TrackedInt(20));
+	EXPECT_EQ(set.size(), 2);
+
+	TrackedInt::reset_counts();
+
+	size_t erased_count = set.erase_if([](const TrackedInt& key) { return key.dirty; });
+
+	EXPECT_EQ(erased_count, 0);
+	EXPECT_EQ(set.size(), 2);
+}
+
+TEST_F(DirtySetTest, ReclaimTombstoneOnEmplace) {
+	set.emplace(TrackedInt(10));
+	set.emplace(TrackedInt(20, true));
+	set.emplace(TrackedInt(30));
+
+	// Erase 20, creating a tombstone
+	set.erase_if([](const TrackedInt& key) { return key.dirty; });
+	EXPECT_EQ(set.size(), 2);
+
+	TrackedInt::reset_counts();
+
+	// Emplace a new element. It should reclaim the tombstone slot.
+	auto [it, inserted] = set.emplace(TrackedInt(40));
+
+	EXPECT_TRUE(inserted);
+	EXPECT_EQ(set.size(), 3);
+	EXPECT_EQ(it->id, 40);
+}
+
+TEST_F(DirtySetTest, TriggerRehash) {
+	// With a load factor of 0.85, inserting 7 elements into a table of size 8
+	// (7/8 = 0.875) will trigger a rehash on the 7th emplace.
+	for (int i = 0; i < 7; ++i) {
+		set.emplace(TrackedInt(i));
+	}
+
+	EXPECT_EQ(set.size(), 7);
+
+	// Verify all elements are still present and findable after rehash
+	for (int i = 0; i < 7; ++i) {
+		auto it = set.emplace(TrackedInt(i)).first;
+		ASSERT_NE(it, set.end());
+		EXPECT_EQ(it->id, i);
+	}
+}
+
+TEST_F(DirtySetTest, LifetimeCheckAfterRehash) {
+	{
+		DirtySet<TrackedInt, TrackedIntHash> local_set;
+		for (int i = 0; i < 100; ++i) {
+			local_set.emplace(TrackedInt(i));
+		}
+		EXPECT_EQ(local_set.size(), 100);
+	} // local_set is destroyed here
+}
+
+TEST_F(DirtySetTest, Clear) {
+	for (int i = 0; i < 50; ++i) {
+		set.emplace(TrackedInt(i));
+	}
+	EXPECT_EQ(set.size(), 50);
+
+	size_t destructions_before_clear = TrackedInt::destructions;
+
+	set.clear();
+
+	EXPECT_EQ(set.size(), 0);
+	EXPECT_TRUE(set.empty());
+
+	// Check that clear() destroyed exactly the number of elements that were in the set.
+	size_t destroyed_by_clear = TrackedInt::destructions - destructions_before_clear;
+	EXPECT_GE(destroyed_by_clear, 50);
+}
+
+TEST_F(DirtySetTest, Iteration) {
+	for (int i = 0; i < 10; ++i) {
+		set.emplace(TrackedInt(i * 10));
+	}
+
+	std::vector<int> found_ids;
+	for (const auto& key : set) {
+		found_ids.push_back(key.id);
+	}
+	std::sort(found_ids.begin(), found_ids.end());
+
+	ASSERT_EQ(found_ids.size(), 10);
+	for (int i = 0; i < 10; ++i) {
+		EXPECT_EQ(found_ids[i], i * 10);
+	}
+}
+
+TEST_F(DirtySetTest, CopyConstructorAndAssignment) {
+	for (int i = 0; i < 10; ++i) {
+		set.emplace(TrackedInt(i));
+	}
+
+	TrackedInt::reset_counts();
+
+	// Test Copy Constructor
+	DirtySet<TrackedInt, TrackedIntHash> set2 = set;
+	EXPECT_EQ(set.size(), 10);
+	EXPECT_EQ(set2.size(), 10);
+	EXPECT_EQ(TrackedInt::copies, 10); // 10 elements copied
+
+	TrackedInt::reset_counts();
+
+	// Test Copy Assignment
+	DirtySet<TrackedInt, TrackedIntHash> set3;
+	set3.emplace(TrackedInt(99)); // To ensure old elements are destroyed
+	set3 = set;
+	EXPECT_EQ(set3.size(), 10);
+}
+
+TEST_F(DirtySetTest, MoveConstructorAndAssignment) {
+	for (int i = 0; i < 10; ++i) {
+		set.emplace(TrackedInt(i));
+	}
+
+	TrackedInt::reset_counts();
+
+	// Test Move Constructor
+	DirtySet<TrackedInt, TrackedIntHash> set2 = std::move(set);
+	EXPECT_EQ(set2.size(), 10);
+
+	// Test Move Assignment
+	DirtySet<TrackedInt, TrackedIntHash> set3;
+	set3.emplace(TrackedInt(99));
+	TrackedInt::reset_counts();
+
+	set3 = std::move(set2);
+	EXPECT_EQ(set3.size(), 10);
+}
+
+TEST_F(DirtySetTest, EmplaceIntoSaturatedTableWithTombstones) {
+	// 1. Determine initial capacity. emplace triggers growth to 8.
+	set.emplace(TrackedInt(0));
+	int initial_capacity = 8; // Based on our implementation's growth logic
+
+	// 2. Fill the table to its absolute capacity with live elements.
+	for (int i = 1; i < initial_capacity; ++i) {
+		set.emplace(TrackedInt(i));
+	}
+	ASSERT_EQ(set.size(), initial_capacity);
+
+	// 3. Erase some elements, creating tombstones but keeping the table saturated.
+	set.erase_if([](const TrackedInt& k) { return k.id % 2 == 0; }); // Erase 0, 2, 4, 6
+	ASSERT_EQ(set.size(), 4); // Size is low, but all 8 slots are occupied.
+
+	// 4. THIS IS THE TRIGGER: Try to emplace a NEW element that doesn't exist.
+	// The load factor check (5/8) will pass, but the table has no empty slots.
+	// This will cause the infinite loop.
+	auto [it, inserted] = set.emplace(TrackedInt(99));
+
+	// If the test doesn't hang, we can verify correctness.
+	EXPECT_TRUE(inserted);
+	EXPECT_EQ(set.size(), 5);
+}
+
+// A variation to ensure lookups don't infinite loop.
+TEST_F(DirtySetTest, FindExistingInSaturatedTableWithTombstones) {
+	set.emplace(TrackedInt(0));
+	int initial_capacity = 8;
+	for (int i = 1; i < initial_capacity; ++i) {
+		set.emplace(TrackedInt(i));
+	}
+	set.erase_if([](const TrackedInt& k) { return k.id % 2 == 0; }); // Erase evens
+
+	// This should NOT loop, because the "key exists" condition will terminate the loop.
+	auto [it, inserted] = set.emplace(TrackedInt(1)); // Key 1 still exists
+	EXPECT_FALSE(inserted);
+	EXPECT_EQ(it->id, 1);
+}

--- a/tests/snippets/merge.cpp
+++ b/tests/snippets/merge.cpp
@@ -2,29 +2,24 @@
 #include <iostream>
 
 void merge_snippets() {
-    //! [merge_inplace]
-    // Create a container with several duplicate Pauli strings.
-    PauliTermContainer<float> observable = {
-        "+0.5XXI",
-        "-0.2IZY",
-        "+0.1XXI",
-        "+0.8ZZZ",
-        "+0.4IZY"
-    };
+	//! [merge_inplace]
+	// Create a container with several duplicate Pauli strings.
+	PauliTermContainer<float> observable = { "+0.5XXI", "-0.2IZY", "+0.1XXI", "+0.8ZZZ", "+0.4IZY" };
+	Merger<float> merger{};
 
-    std::cout << "Observable before merging (" << observable.nb_terms() << " terms):" << std::endl;
-    for (const auto& term : observable) {
-        std::cout << "  " << term << std::endl;
-    }
+	std::cout << "Observable before merging (" << observable.nb_terms() << " terms):" << std::endl;
+	for (const auto& term : observable) {
+		std::cout << "  " << term << std::endl;
+	}
 
-    // Merge the terms in-place.
-    merge_inplace_noalloc(observable);
+	// Merge the terms in-place.
+	merger(observable);
 
-    std::cout << "\nObservable after merging (" << observable.nb_terms() << " terms):" << std::endl;
-    // Note: The order of terms is not guaranteed after merging.
-    // Expected terms: (+0.6 XXI), (+0.2 IZY), (+0.8 ZZZ)
-    for (const auto& term : observable) {
-        std::cout << "  " << term << std::endl;
-    }
-    //! [merge_inplace]
+	std::cout << "\nObservable after merging (" << observable.nb_terms() << " terms):" << std::endl;
+	// Note: The order of terms is not guaranteed after merging.
+	// Expected terms: (+0.6 XXI), (+0.2 IZY), (+0.8 ZZZ)
+	for (const auto& term : observable) {
+		std::cout << "  " << term << std::endl;
+	}
+	//! [merge_inplace]
 }


### PR DESCRIPTION
I completely reworked the merge algorithm.

Before, there was an enormous of RAM used, not allowing to go beyond 30K Pauli terms. The execution was slow, with a max cut on a QAOA N=32 p=3 taking 20 Go+ of RAM and 110 seconds to run.

This PR introduces:
- an optimized hash set specifically tailored for our needs, with support for SSE2 acceleration and more.
- a new Merger object
- a max cut QAOA benchmark.

The time for the max cut went down to 210 ms and the RAM usage to 6 Mio, in the same condition.