### PR TITLE
Hotfix: KeepN is one off

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ set(BENCHMARK OFF CACHE BOOL "Build benchmarks")
 set(TEST OFF CACHE BOOL "Build tests")
 
 project(ProPauli
-	VERSION 3.2.0
+	VERSION 3.2.1
 DESCRIPTION "Fast and efficient C++ library for Pauli Propagation"
 	LANGUAGES CXX)
 

--- a/include/truncate.hpp
+++ b/include/truncate.hpp
@@ -302,7 +302,7 @@ class KeepNTruncator : public Truncator<T> {
 		// Partition the container. We use a custom comparator on the absolute value
 		// of the coefficients. Note the '>' to find the N-th *largest*.
 		std::nth_element(paulis.begin(), nth_it, paulis.end(),
-				 [](auto const& a, auto const& b) { return std::abs(a.coefficient()) > std::abs(b.coefficient()); });
+				 [](auto const& a, auto const& b) { return std::abs(a.coefficient()) >= std::abs(b.coefficient()); });
 
 		// After partitioning, the N largest elements are in the range [begin(), nth_it).
 		// All elements from nth_it to the end can be safely removed.

--- a/include/truncate.hpp
+++ b/include/truncate.hpp
@@ -297,7 +297,7 @@ class KeepNTruncator : public Truncator<T> {
 
 		// The goal is to find the N-th largest element.
 		// std::nth_element will place this element at the specified iterator position.
-		auto nth_it = paulis.begin() + nb_terms;
+		auto nth_it = paulis.begin() + (nb_terms-1);
 
 		// Partition the container. We use a custom comparator on the absolute value
 		// of the coefficients. Note the '>' to find the N-th *largest*.

--- a/include/truncate.hpp
+++ b/include/truncate.hpp
@@ -24,6 +24,10 @@
 #include <tuple>
 #include <type_traits>
 #include <utility>
+#include <vector>
+#include <cmath>
+#include <stdexcept>
+#include <cassert>
 
 /**
  * @brief A predicate that returns true if a PauliTerm's coefficient magnitude is below a threshold.
@@ -270,14 +274,13 @@ class RuntimeMultiTruncators : public Truncator<T> {
  */
 template <typename T = coeff_t>
 class KeepNTruncator : public Truncator<T> {
+	// A cutoff for switching to the more efficient insertion sort on small partitions.
+	// A value between 8 and 24 is typical.
+	static constexpr std::size_t INSERTION_SORT_CUTOFF = 16;
+
 	std::size_t nb_terms;
 
     public:
-	/**
-	 * @brief Constructs the truncator to keep a maximum number of terms.
-	 * @param max_n The maximum number of terms to keep.
-	 * @throws std::invalid_argument if max_n is 0.
-	 */
 	KeepNTruncator(std::size_t max_n) : nb_terms(max_n) {
 		if (nb_terms == 0) {
 			throw std::invalid_argument("Must keep at least one term.");
@@ -295,23 +298,93 @@ class KeepNTruncator : public Truncator<T> {
 
 		const auto initial_size = paulis.nb_terms();
 
-		// The goal is to find the N-th largest element.
-		// std::nth_element will place this element at the specified iterator position.
-		auto nth_it = paulis.begin() + (nb_terms-1);
+		// We need to ensure the N largest elements are in the first N positions.
+		// This means we need to find the element that belongs at index `nb_terms - 1`.
+		selection_by_swap(paulis, 0, paulis.nb_terms() - 1, nb_terms - 1,
+				  [](auto const& a, auto const& b) { return std::abs(a.coefficient()) > std::abs(b.coefficient()); });
 
-		// Partition the container. We use a custom comparator on the absolute value
-		// of the coefficients. Note the '>' to find the N-th *largest*.
-		std::nth_element(paulis.begin(), nth_it, paulis.end(),
-				 [](auto const& a, auto const& b) { return std::abs(a.coefficient()) >= std::abs(b.coefficient()); });
-
-		// After partitioning, the N largest elements are in the range [begin(), nth_it).
-		// All elements from nth_it to the end can be safely removed.
 		paulis.erase_to_end(nb_terms);
 
 		assert(paulis.nb_terms() == nb_terms);
-
 		return initial_size - paulis.nb_terms();
 	}
-};
 
+    private:
+	/**
+	 * @brief The main Quickselect routine with a cutoff for small partitions.
+	 */
+	template <typename Compare>
+	void selection_by_swap(PauliTermContainer<T>& paulis, std::size_t left, std::size_t right, std::size_t k, Compare comp) {
+		while (right - left > INSERTION_SORT_CUTOFF) {
+			std::size_t pivot_index = partition(paulis, left, right, comp);
+
+			if (pivot_index == k) {
+				return;
+			} else if (pivot_index < k) {
+				left = pivot_index + 1;
+			} else { // pivot_index > k
+				right = pivot_index - 1;
+			}
+		}
+
+		// For the small remaining partition, finish with a full (but swap-based) sort.
+		insertion_sort_by_swap(paulis, left, right, comp);
+	}
+
+	/**
+	 * @brief A robust partitioning scheme using a median-of-three pivot.
+	 */
+	template <typename Compare>
+	std::size_t partition(PauliTermContainer<T>& paulis, std::size_t left, std::size_t right, Compare comp) {
+		// --- Median-of-Three Pivot Selection ---
+		std::size_t mid = left + (right - left) / 2;
+		// Sort the elements at left, mid, and right using swaps.
+		if (comp(paulis[mid], paulis[left])) {
+			paulis.swap_fast(left, mid);
+		}
+		if (comp(paulis[right], paulis[left])) {
+			paulis.swap_fast(left, right);
+		}
+		if (comp(paulis[right], paulis[mid])) {
+			paulis.swap_fast(mid, right);
+		}
+		// The median is now at paulis[mid]. Swap it into the pivot position (right-1)
+		// to simplify the partitioning loop.
+		paulis.swap_fast(mid, right - 1);
+		auto pivot_proxy = paulis[right - 1];
+		// --- End of Pivot Selection ---
+
+		std::size_t i = left;
+		std::size_t j = right - 1;
+
+		// Hoare-style partitioning loop
+		while (true) {
+			while (comp(paulis[++i], pivot_proxy))
+				;
+			while (comp(pivot_proxy, paulis[--j]))
+				;
+			if (i >= j)
+				break;
+			paulis.swap_fast(i, j);
+		}
+		// Swap the pivot back to its final place.
+		paulis.swap_fast(i, right - 1);
+		return i;
+	}
+
+	/**
+	 * @brief A classic insertion sort that uses only swaps, making it safe for proxies.
+	 */
+	template <typename Compare>
+	void insertion_sort_by_swap(PauliTermContainer<T>& paulis, std::size_t left, std::size_t right, Compare comp) {
+		for (std::size_t i = left + 1; i <= right; ++i) {
+			std::size_t j = i;
+			// "Bubble" the current element leftwards until it's in its sorted place.
+			while (j > left && comp(paulis[j], paulis[j - 1])) {
+				paulis.swap_fast(j, j - 1);
+				--j;
+			}
+		}
+	}
+};
 #endif

--- a/include/truncate.hpp
+++ b/include/truncate.hpp
@@ -268,8 +268,7 @@ class RuntimeMultiTruncators : public Truncator<T> {
  * This truncator ensures that after truncation, the observable contains at most `N` terms.
  * It identifies the `N` terms with the largest coefficients norms and removes all others.
  *
- * @note The selection uses an efficient heap-based selection algorithm to find the removal
- * threshold without performing a full sort of the terms.
+ * @note Amortized O(n) complexity. Inspired from the code from the STL, but tweaked to work with proxy iterators.
  *
  */
 template <typename T = coeff_t>
@@ -387,4 +386,5 @@ class KeepNTruncator : public Truncator<T> {
 		}
 	}
 };
+
 #endif

--- a/tests/truncator.cpp
+++ b/tests/truncator.cpp
@@ -5,6 +5,16 @@
 #include <memory>
 #include <random>
 
+bool is_in(PauliTermContainer<coeff_t> const& pts, PauliTerm<coeff_t> const& needle) {
+	for (std::size_t i = 0; i < pts.nb_terms(); ++i) {
+		auto nopt = pts[i];
+		if (nopt == needle) {
+			return true;
+		}
+	}
+	return false;
+}
+
 TEST(Truncator, CoefficientTruncator) {
 	CoefficientTruncator<> ct{ 0.1f };
 	std::vector<PauliTerm<coeff_t>> pts_data = { { "I", 0.99 }, { "Y", 0.01 }, { "X", 0.5 } };
@@ -38,18 +48,160 @@ TEST(Truncator, WeightTruncator) {
 	EXPECT_EQ(pts[0], ept);
 }
 
-TEST(Truncator, KeepNTruncator) {
-	KeepNTruncator nt{ 2 };
+TEST(Truncator, KeepNTruncator_basic_positive) {
+	static constexpr std::size_t keep_n = 2;
+	KeepNTruncator nt{ keep_n };
+	std::vector<PauliTerm<coeff_t>> pts_data = { { "IIII", 0.1 }, { "YYYY", 0.2 }, { "IIIX", 0.3 }, { "ZZZZ", 0.4 } };
+	PauliTermContainer<coeff_t> pts{ pts_data };
+	std::vector<PauliTerm<coeff_t>> expected_in = { { "IIIX", 0.3 }, { "ZZZZ", 0.4 } };
+	EXPECT_EQ(pts_data.size(), pts.nb_terms());
+	EXPECT_EQ(expected_in.size(), keep_n);
+
+	auto removed = nt.truncate(pts);
+
+	EXPECT_EQ(pts.nb_terms(), keep_n);
+	EXPECT_EQ(removed, pts_data.size() - keep_n);
+	for (auto const& needle : expected_in) {
+		EXPECT_TRUE(is_in(pts, needle));
+	}
+}
+
+TEST(Truncator, KeepNTruncator_basic_negative) {
+	static constexpr std::size_t keep_n = 2;
+	KeepNTruncator nt{ keep_n };
+	std::vector<PauliTerm<coeff_t>> pts_data = { { "IIII", -0.1 }, { "YYYY", -0.2 }, { "IIIX", -0.3 }, { "ZZZZ", -0.4 } };
+	PauliTermContainer<coeff_t> pts{ pts_data };
+	std::vector<PauliTerm<coeff_t>> expected_in = { { "IIIX", -0.3 }, { "ZZZZ", -0.4 } };
+	EXPECT_EQ(pts_data.size(), pts.nb_terms());
+	EXPECT_EQ(expected_in.size(), keep_n);
+
+	auto removed = nt.truncate(pts);
+
+	EXPECT_EQ(pts.nb_terms(), keep_n);
+	EXPECT_EQ(removed, pts_data.size() - keep_n);
+	for (auto const& needle : expected_in) {
+		EXPECT_TRUE(is_in(pts, needle));
+	}
+}
+
+TEST(Truncator, KeepNTruncator_basic_mixed_signs) {
+	static constexpr std::size_t keep_n = 2;
+	KeepNTruncator nt{ keep_n };
+	std::vector<PauliTerm<coeff_t>> pts_data = { { "IIII", -0.1 }, { "YYYY", 0.2 }, { "IIIX", 0.3 }, { "ZZZZ", -0.4 } };
+	PauliTermContainer<coeff_t> pts{ pts_data };
+	std::vector<PauliTerm<coeff_t>> expected_in = { { "IIIX", 0.3 }, { "ZZZZ", -0.4 } };
+	EXPECT_EQ(pts_data.size(), pts.nb_terms());
+	EXPECT_EQ(expected_in.size(), keep_n);
+
+	auto removed = nt.truncate(pts);
+
+	EXPECT_EQ(pts.nb_terms(), keep_n);
+	EXPECT_EQ(removed, pts_data.size() - keep_n);
+	for (auto const& needle : expected_in) {
+		EXPECT_TRUE(is_in(pts, needle));
+	}
+}
+
+auto keepn_test_stl(PauliTermContainer<coeff_t> const& ptc, std::vector<PauliTerm<coeff_t>> const& data, std::size_t kn) {
+	std::vector<coeff_t> coeffs_only;
+	coeffs_only.reserve(ptc.nb_terms());
+	for (const auto& term : ptc) {
+		coeffs_only.push_back(std::abs(term.coefficient()));
+	}
+
+	// 2. Perform the EXACT same nth_element and resize logic on this simple vector.
+	auto nth_it_coeffs = coeffs_only.begin() + (kn);
+	std::nth_element(coeffs_only.begin(), nth_it_coeffs, coeffs_only.end(), std::greater<coeff_t>{});
+	coeffs_only.resize(kn); // This is equivalent to your erase_to_end(kn)
+
+	// 3. Sort both the result and the ground truth for easy comparison.
+	std::sort(coeffs_only.begin(), coeffs_only.end());
+
+	std::vector<coeff_t> ground_truth_coeffs;
+	ground_truth_coeffs.reserve(data.size());
+	for (size_t i = 0; i < data.size(); ++i) {
+		ground_truth_coeffs.push_back(std::abs(data[i].coefficient()));
+	}
+	std::sort(ground_truth_coeffs.begin(), ground_truth_coeffs.end(), [](auto l, auto r) { return l > r; });
+	ground_truth_coeffs.resize(kn);
+	std::reverse(ground_truth_coeffs.begin(), ground_truth_coeffs.end());
+
+	// 4. Assert that the results are identical.
+	// This proves the algorithm works correctly on standard types.
+	return std::pair{ coeffs_only, ground_truth_coeffs };
+}
+
+TEST(Truncator, KeepNTruncator_edge_case) {
+	static constexpr std::size_t keep_n = 2;
+	KeepNTruncator nt{ keep_n };
 	std::vector<PauliTerm<coeff_t>> pts_data = {
-		{ "IIII", 0.49 }, { "YYYY", -0.49 }, { "IIIX", 0.02 }, { "ZZZZ", 0.1 }
+		{ "IIII", 0.5 }, { "ZYXI", 0.11 }, { "YYYY", -0.6 }, { "IXYZ", 0.1 }, { "IIIX", -0.4 }
 	};
 	PauliTermContainer<coeff_t> pts{ pts_data };
-	auto ept = pts[0];
+	std::vector<PauliTerm<coeff_t>> expected_in = { { "YYYY", -0.6 }, { "IIII", 0.5 } };
+	EXPECT_EQ(pts_data.size(), pts.nb_terms());
+	EXPECT_EQ(expected_in.size(), keep_n);
+
 	auto removed = nt.truncate(pts);
-	EXPECT_EQ(removed, 2);
-	EXPECT_EQ(pts.nb_terms(), 2);
-	EXPECT_EQ(pts[0], ept);
-	EXPECT_EQ(pts[1], PauliTerm("YYYY", -0.49));
+
+	EXPECT_EQ(pts.nb_terms(), keep_n);
+	EXPECT_EQ(removed, pts_data.size() - keep_n);
+	for (auto const& needle : expected_in) {
+		EXPECT_TRUE(is_in(pts, needle));
+	}
+}
+
+// X times: Generate observable of Mx N qubits pauli term, KeepN=L a random number, ensure it is correctly done.
+TEST(Truncator, KeepNTruncator_random) {
+	static constexpr std::size_t nb_runs = 100;
+	static constexpr std::size_t pauli_size = 8;
+	static constexpr std::size_t obs_size = 5;
+	static constexpr std::string_view chars = "IXYZ";
+	std::mt19937 gen{ 42 };
+	std::uniform_int_distribution<> dis_ps(0, chars.size() - 1);
+	std::uniform_int_distribution<> dis_kn{ 2, obs_size - 1 };
+	std::uniform_real_distribution<coeff_t> dis_coeff{ 0.f, 1.f };
+	for (std::size_t k = 0; k < nb_runs; ++k) {
+		std::vector<PauliTerm<coeff_t>> data;
+		data.reserve(obs_size);
+		std::generate_n(std::back_inserter(data), obs_size, [&]() {
+			std::string ps(pauli_size, 'I');
+			for (std::size_t i = 0; i < ps.size(); ++i)
+				ps[i] = chars[dis_ps(gen)];
+			return PauliTerm<coeff_t>{ ps, dis_coeff(gen) };
+		});
+		PauliTermContainer<coeff_t> ptc{ data };
+
+		std::size_t kn = dis_kn(gen);
+		KeepNTruncator kt{ kn };
+
+		// check that the STL implementation is correct
+		auto [coeffs_only, ground_truth_coeffs] = keepn_test_stl(ptc, data, kn);
+		EXPECT_EQ(coeffs_only.size(), kn);
+		EXPECT_EQ(coeffs_only, ground_truth_coeffs) << "Isolation test failed: The bug might be in the truncate logic itself!";
+
+		kt.truncate(ptc);
+
+		std::sort(data.begin(), data.end(),
+			  [](auto const& lhs, auto const& rhs) { return abs(lhs.coefficient()) < abs(rhs.coefficient()); });
+		std::reverse(data.begin(), data.end());
+
+		bool ok = true;
+		std::size_t i = 0;
+		for (i = 0; ok && i < kn; ++i) {
+			ok = ok && is_in(ptc, data[i]);
+			EXPECT_TRUE(ok);
+		}
+		if (!ok) {
+			std::cerr << data[i - 1] << " not found for KeepN=" << kn << "\n\nOriginal data (sorted):\n";
+			for (std::size_t i = 0; i < data.size(); ++i)
+				std::cerr << i << ": " << data[i] << (i < kn ? "\n" : "[deleted]\n");
+			std::cerr << "\n\nResult from KeepN:\n";
+			for (std::size_t i = 0; i < ptc.nb_terms(); ++i)
+				std::cerr << i << ": " << ptc[i] << "\n";
+		}
+		ASSERT_TRUE(ok);
+	}
 }
 
 TEST(Truncator, MultiTruncator) {
@@ -68,8 +220,7 @@ TEST(Truncator, MultiTruncator) {
 TEST(Truncator, polymorphism) {
 	std::shared_ptr<Truncator<coeff_t>> ptr = std::make_shared<WeightTruncator<>>(3);
 	std::shared_ptr<Truncator<coeff_t>> ptr2 = std::make_shared<CoefficientTruncator<>>(0.01f);
-	std::shared_ptr<Truncator<coeff_t>> ptr3 =
-		combine_truncators(WeightTruncator<>{ 3 }, CoefficientTruncator<>{ 0.01f });
+	std::shared_ptr<Truncator<coeff_t>> ptr3 = combine_truncators(WeightTruncator<>{ 3 }, CoefficientTruncator<>{ 0.01f });
 	std::shared_ptr<Truncator<coeff_t>> ptr4 = std::make_shared<NeverTruncator<>>();
 
 	std::vector<PauliTerm<coeff_t>> pts_data = { { "IIII", 0.49 }, { "YYYY", 0.49 }, { "IIIX", 0.02 } };
@@ -107,14 +258,11 @@ TEST(Truncator, CustomTruncator) {
 }
 
 TEST(Truncator, multiple_truncators_at_runtime) {
-	std::shared_ptr<Truncator<coeff_t>> mt =
-		combine_truncators(WeightTruncator<>{ 3 }, CoefficientTruncator<>{ 0.1f });
+	std::shared_ptr<Truncator<coeff_t>> mt = combine_truncators(WeightTruncator<>{ 3 }, CoefficientTruncator<>{ 0.1f });
 	std::shared_ptr<Truncator<coeff_t>> dft = std::make_shared<DeleteFirstTruncator<coeff_t>>();
 	auto runtime_mt = RuntimeMultiTruncators<coeff_t>{ mt, dft };
 
-	std::vector<PauliTerm<coeff_t>> pts_data = {
-		{ "IIII", 0.49 }, { "YYYY", 0.49 }, { "IIIX", 0.02 }, { "IIIX", 0.3 }
-	};
+	std::vector<PauliTerm<coeff_t>> pts_data = { { "IIII", 0.49 }, { "YYYY", 0.49 }, { "IIIX", 0.02 }, { "IIIX", 0.3 } };
 	PauliTermContainer<coeff_t> pts{ pts_data };
 	auto removed = runtime_mt.truncate(pts);
 	EXPECT_EQ(removed, 3);


### PR DESCRIPTION
Proxy iterators did not work with STL implementation of insertion sort, leading to small errors.

* Rewrote std::nth_element from scratch.