### PR TITLE
Compiled symbolic expression for fast evaluation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ set(BENCHMARK OFF CACHE BOOL "Build benchmarks")
 set(TEST OFF CACHE BOOL "Build tests")
 
 project(ProPauli
-	VERSION 3.2.1
+	VERSION 3.3.0
 DESCRIPTION "Fast and efficient C++ library for Pauli Propagation"
 	LANGUAGES CXX)
 
@@ -94,6 +94,12 @@ if (TEST)
 	target_link_libraries(UnitTest propaulib gtest gtest_main gmock)
 	target_include_directories(UnitTest PUBLIC ${INCLUDE_DIR})
 	gtest_discover_tests(UnitTest)
+
+	set_source_files_properties(
+	    "${PROJECT_SOURCE_DIR}/tests/compiled_expression.cpp"
+	    PROPERTIES
+	    COMPILE_FLAGS "-fno-fast-math"
+	)
 endif()
 
 # GoogleBenchmark

--- a/include/symbolic/coefficient.hpp
+++ b/include/symbolic/coefficient.hpp
@@ -48,6 +48,12 @@ class SymbolicCoefficient {
 	 */
 	SymbolicCoefficient(Variable const& var) : et(ExpressionTree<T>(std::make_shared<const ExpressionNode<T>>(var))) {}
 
+	/**
+	 * @brief Constructs a symbolic coefficient from a variable NAME.
+	 * @param varname Name of the variable.
+	 */
+	SymbolicCoefficient(std::string const& varname) : SymbolicCoefficient{ Variable{ varname } } {}
+
 	SymbolicCoefficient(SymbolicCoefficient const&) = default;
 	SymbolicCoefficient& operator=(SymbolicCoefficient const&) = default;
 	SymbolicCoefficient(SymbolicCoefficient&&) = default;
@@ -96,6 +102,18 @@ class SymbolicCoefficient {
 	 * @return A new `SymbolicCoefficient` representing the simplified expression.
 	 */
 	[[nodiscard]] SymbolicCoefficient simplified() const { return SymbolicCoefficient(et.simplified()); }
+
+	/*
+	 * @brief Compiles the expression to make it faster to evaluate.
+	 * @return a new `CompiledExpression` representing the compiled version of this object.
+	 */
+	[[nodiscard]] CompiledExpression<T> compile() const { return et.compile(); }
+
+	/*
+	 * @brief Optimize the expression for faster evaluation.
+	 * @return A simplified and compiled expression.
+	 */
+	[[nodiscard]] CompiledExpression<T> optimize() const { return et.simplified().compile(); }
 
 	/**
 	 * @brief In-place multiplication by a scalar.
@@ -208,6 +226,9 @@ class SymbolicCoefficient {
 	friend SymbolicCoefficient sqrt(SymbolicCoefficient x) { return x.sqrt(); }
 
 	friend std::ostream& operator<<(std::ostream& os, SymbolicCoefficient const& sc) { return os << sc.et; }
+
+	ExpressionTree<T>& get_expression_tree() { return et; }
+	ExpressionTree<T> const& get_expression_tree() const { return et; }
 };
 
 /**

--- a/include/symbolic/compiled_expression.hpp
+++ b/include/symbolic/compiled_expression.hpp
@@ -1,0 +1,109 @@
+#ifndef PP_INCLUDE_COMPILED_EXPRESSION_HPP
+#define PP_INCLUDE_COMPILED_EXPRESSION_HPP
+
+#include "expression_tree/nodes.hpp"
+#include "maths.hpp"
+
+#include <map>
+#include <stdexcept>
+#include <type_traits>
+#include <unordered_map>
+#include <variant>
+#include <vector>
+
+template <typename T>
+class ExpressionTree;
+
+template <typename T>
+using CompiledConstant = Constant<T>;
+
+struct CompiledVariable {
+	std::size_t variable_index;
+};
+
+struct CompiledUnaryOp {
+	enum class Op { Cos, Sin, Minus, Sqrt } operation;
+	std::size_t node_index;
+};
+
+struct CompiledBinaryOp {
+	enum class Op { Add, Multiply, Substract, Divide } operation;
+	std::size_t lhs_index;
+	std::size_t rhs_index;
+};
+
+template <typename T>
+using CompiledNode = std::variant<CompiledConstant<T>, CompiledVariable, CompiledUnaryOp, CompiledBinaryOp>;
+
+template <typename T>
+class CompiledExpression {
+    private:
+	std::vector<CompiledNode<T>> nodes;
+	std::vector<std::string> variables_names;
+
+	struct Compiler;
+
+	CompiledExpression(ExpressionTree<T> const& tree);
+
+    public:
+	T evaluate(std::unordered_map<std::string, T> const& variables) const {
+		std::vector<T> variables_values;
+		variables_values.reserve(variables_names.size());
+		for (auto const& name : variables_names) {
+			auto it = variables.find(name);
+			if (it == variables.end()) {
+				throw std::invalid_argument("Unbound variable in compiled expression evaluation: " + name);
+			}
+			variables_values.push_back(it->second);
+		}
+
+		std::vector<T> results(nodes.size()); // temporary register
+
+		for (std::size_t i = 0; i < nodes.size(); ++i) {
+			std::visit(
+				[&](auto const& node) {
+					using n_t = std::decay_t<decltype(node)>;
+					if constexpr (std::is_same_v<CompiledConstant<T>, n_t>) {
+						results[i] = node.value;
+					} else if constexpr (std::is_same_v<CompiledVariable, n_t>) {
+						results[i] = variables_values[node.variable_index];
+					} else if constexpr (std::is_same_v<CompiledUnaryOp, n_t>) {
+						switch (node.operation) {
+						case CompiledUnaryOp::Op::Minus:
+							results[i] = -results[node.node_index];
+							break;
+						case CompiledUnaryOp::Op::Sqrt:
+							results[i] = sqrt(results[node.node_index]);
+							break;
+						case CompiledUnaryOp::Op::Cos:
+							results[i] = cos(results[node.node_index]);
+							break;
+						case CompiledUnaryOp::Op::Sin:
+							results[i] = sin(results[node.node_index]);
+							break;
+						}
+					} else if constexpr (std::is_same_v<CompiledBinaryOp, n_t>) {
+						switch (node.operation) {
+						case CompiledBinaryOp::Op::Add:
+							results[i] = results[node.lhs_index] + results[node.rhs_index];
+							break;
+						case CompiledBinaryOp::Op::Multiply:
+							results[i] = results[node.lhs_index] * results[node.rhs_index];
+							break;
+						case CompiledBinaryOp::Op::Substract:
+							results[i] = results[node.lhs_index] - results[node.rhs_index];
+							break;
+						case CompiledBinaryOp::Op::Divide:
+							results[i] = results[node.lhs_index] / results[node.rhs_index];
+							break;
+						}
+					}
+				},
+				nodes[i]);
+		}
+
+		return results.back();
+	}
+};
+
+#endif

--- a/include/symbolic/compiled_expression.hpp
+++ b/include/symbolic/compiled_expression.hpp
@@ -43,10 +43,14 @@ class CompiledExpression {
 
 	struct Compiler;
 
+    public:
 	CompiledExpression(ExpressionTree<T> const& tree);
 
-    public:
 	T evaluate(std::unordered_map<std::string, T> const& variables) const {
+		if (nodes.size() == 0) {
+			return T{ 0 };
+		}
+
 		std::vector<T> variables_values;
 		variables_values.reserve(variables_names.size());
 		for (auto const& name : variables_names) {

--- a/include/symbolic/compiler.inl
+++ b/include/symbolic/compiler.inl
@@ -1,0 +1,115 @@
+#ifndef PP_INCLUDE_COMPILER_INL
+#define PP_INCLUDE_COMPILER_INL
+
+// --- CRITICAL INCLUDES ---
+// These bring in the full definitions of both classes.
+#include "symbolic/compiled_expression.hpp"
+
+#include <map> // Needed for the compiler's caches
+
+// --- IMPLEMENTATION OF THE COMPILER HELPER STRUCT ---
+template <typename T>
+struct CompiledExpression<T>::Compiler {
+	CompiledExpression<T>& parent;
+	ExpressionTree<T> const& source_tree;
+
+	std::unordered_map<T, std::size_t> constant_cache;
+	std::unordered_map<std::string, std::size_t> variable_cache;
+	std::map<NodePtr<T>, std::size_t, typename ExpressionTree<T>::NodePtrComparator> memo;
+
+	Compiler(CompiledExpression<T>& p, ExpressionTree<T> const& tree) : parent(p), source_tree(tree), memo({ &source_tree }) {}
+
+	void run() {
+		if (auto root = source_tree.get_root()) {
+			compile_node(root);
+		}
+	}
+
+	std::size_t compile_node(NodePtr<T> const& node) {
+		// 1. Check CSE cache
+		if (auto const it = memo.find(node); it != memo.end()) {
+			return it->second;
+		}
+
+		// 2. Compile the node (post-order traversal)
+		std::size_t new_node_index = std::visit(
+			[&](auto const& n) -> std::size_t {
+				using VT = std::decay_t<decltype(n)>;
+
+				if constexpr (std::is_same_v<VT, Constant<T>>) {
+					if (auto const it = constant_cache.find(n.value); it != constant_cache.end()) {
+						return it->second;
+					}
+					parent.nodes.push_back(CompiledConstant<T>{ n.value });
+					auto index = parent.nodes.size() - 1;
+					constant_cache[n.value] = index;
+					return index;
+				} else if constexpr (std::is_same_v<VT, Variable>) {
+					if (auto const it = variable_cache.find(n.name); it != variable_cache.end()) {
+						return it->second;
+					}
+					auto var_index = parent.variables_names.size();
+					parent.variables_names.push_back(n.name);
+					parent.nodes.push_back(CompiledVariable{ var_index });
+					auto index = parent.nodes.size() - 1;
+					variable_cache[n.name] = index;
+					return index;
+				} else if constexpr (std::is_same_v<VT, UnaryOp<T>>) {
+					auto child_idx = compile_node(n.exp);
+					auto op_type = static_cast<typename CompiledUnaryOp::Op>(n.operation);
+					parent.nodes.push_back(CompiledUnaryOp{ op_type, child_idx });
+					return parent.nodes.size() - 1;
+				} else if constexpr (std::is_same_v<VT, BinaryOp<T>>) {
+					auto lhs_idx = compile_node(n.lhs);
+					auto rhs_idx = compile_node(n.rhs);
+					auto op_type = static_cast<typename CompiledBinaryOp::Op>(n.operation);
+					parent.nodes.push_back(CompiledBinaryOp{ op_type, lhs_idx, rhs_idx });
+					return parent.nodes.size() - 1;
+				} else if constexpr (std::is_same_v<VT, NaryOp<T>>) {
+					if (n.operands.empty()) {
+						// Represent an empty sum as 0, empty product as 1.
+						T identity_val = (n.operation == NaryOp<T>::Op::Add) ? T{ 0 } : T{ 1 };
+						return compile_node(std::make_shared<const ExpressionNode<T>>(Constant<T>{ identity_val }));
+					}
+					if (n.operands.size() == 1) {
+						return compile_node(n.operands[0]);
+					}
+
+					auto op_type = (n.operation == NaryOp<T>::Op::Add) ? CompiledBinaryOp::Op::Add :
+											     CompiledBinaryOp::Op::Multiply;
+
+					std::size_t last_op_idx = compile_node(n.operands[0]);
+					for (size_t i = 1; i < n.operands.size(); ++i) {
+						auto current_rhs_idx = compile_node(n.operands[i]);
+						parent.nodes.push_back(CompiledBinaryOp{ op_type, last_op_idx, current_rhs_idx });
+						last_op_idx = parent.nodes.size() - 1;
+					}
+					return last_op_idx;
+				}
+				// Should not be reached
+				throw std::logic_error("Unsupported node type during compilation");
+			},
+			node->node_type);
+
+		// 3. Cache the result for CSE
+		memo[node] = new_node_index;
+		return new_node_index;
+	}
+};
+
+// --- IMPLEMENTATION OF THE CONSTRUCTOR ---
+template <typename T>
+CompiledExpression<T>::CompiledExpression(ExpressionTree<T> const& tree) {
+	Compiler compiler(this, tree);
+	compiler.run();
+}
+
+// --- IMPLEMENTATION OF THE COMPILE METHOD ---
+template <typename T>
+CompiledExpression<T> ExpressionTree<T>::compile() const {
+	// This method now simply constructs a CompiledExpression from itself.
+	// All the complex logic is encapsulated in the CompiledExpression constructor.
+	return CompiledExpression<T>(*this);
+}
+
+#endif // PP_INCLUDE_COMPILER_INL

--- a/include/symbolic/compiler.inl
+++ b/include/symbolic/compiler.inl
@@ -100,7 +100,7 @@ struct CompiledExpression<T>::Compiler {
 // --- IMPLEMENTATION OF THE CONSTRUCTOR ---
 template <typename T>
 CompiledExpression<T>::CompiledExpression(ExpressionTree<T> const& tree) {
-	Compiler compiler(this, tree);
+	Compiler compiler(*this, tree);
 	compiler.run();
 }
 

--- a/include/symbolic/expression_tree.hpp
+++ b/include/symbolic/expression_tree.hpp
@@ -11,6 +11,7 @@
  */
 
 #include "symbolic/expression_tree/nodes.hpp"
+#include "symbolic/compiled_expression.hpp"
 
 #include "maths.hpp"
 
@@ -99,6 +100,22 @@ class ExpressionTree {
 
 	friend std::ostream& operator<<(std::ostream& os, ExpressionTree const& tree) { return os << tree.to_string(); }
 
+	/**
+	 * @struct NodePtrComparator
+	 * @brief Functor for comparing nodes to establish a canonical order.
+	 */
+	struct NodePtrComparator {
+		const ExpressionTree<T>* tree_instance;
+		bool operator()(const NodePtr<T>& a, const NodePtr<T>& b) const { return tree_instance->compare_nodes(a, b) < 0; }
+	};
+
+	/**
+	 * @brief Compares two nodes for sorting purposes during simplification.
+	 */
+	int compare_nodes(NodePtr<T> const& a, NodePtr<T> const& b) const;
+
+	[[nodiscard]] CompiledExpression<T> compile() const;
+
     private:
 	/**
 	 * @brief Recursively evaluates a node and its children.
@@ -116,10 +133,6 @@ class ExpressionTree {
 	 * @brief Checks if two subtrees are structurally and functionally identical.
 	 */
 	bool are_trees_identical(NodePtr<T> const& a, NodePtr<T> const& b) const;
-	/**
-	 * @brief Compares two nodes for sorting purposes during simplification.
-	 */
-	int compare_nodes(NodePtr<T> const& a, NodePtr<T> const& b) const;
 
 	/**
 	 * @brief Recursively simplifies a node and its children.
@@ -165,15 +178,6 @@ class ExpressionTree {
 	 * @brief Reconstructs a multiplication node from a list of factors.
 	 */
 	NodePtr<T> build_from_factors(const std::vector<NodePtr<T>>& factors) const;
-
-	/**
-	 * @struct NodePtrComparator
-	 * @brief Functor for comparing nodes to establish a canonical order.
-	 */
-	struct NodePtrComparator {
-		const ExpressionTree<T>* tree_instance;
-		bool operator()(const NodePtr<T>& a, const NodePtr<T>& b) const { return tree_instance->compare_nodes(a, b) < 0; }
-	};
 };
 
 #include "expression_tree/evaluate.inl"
@@ -182,5 +186,6 @@ class ExpressionTree {
 #include "expression_tree/simplify.inl"
 #include "expression_tree/factor.inl"
 #include "expression_tree/substitute.inl"
+#include "symbolic/compiler.inl"
 
 #endif // PP_INCLUDE_EXPRESSION_TREE_HPP

--- a/include/symbolic/expression_tree.hpp
+++ b/include/symbolic/expression_tree.hpp
@@ -138,6 +138,12 @@ class ExpressionTree {
 	 * @brief Processes a list of multiplication operands, combining constants and expanding where necessary.
 	 */
 	NodePtr<T> process_multiplication(std::vector<NodePtr<T>>& operands, bool expand = true) const;
+
+	/*
+	 * @brief Process the binary division.
+	 */
+	NodePtr<T> process_division(NodePtr<T>& s_lhs, NodePtr<T>& s_rhs) const;
+
 	/**
 	 * @brief Extracts a numeric coefficient from a node (e.g., 2*x -> {2, x}).
 	 */

--- a/include/symbolic/expression_tree/simplify.inl
+++ b/include/symbolic/expression_tree/simplify.inl
@@ -1,6 +1,7 @@
 #include "simplify/helpers.inl"
 #include "simplify/multiplication.inl"
 #include "simplify/addition.inl"
+#include "simplify/division.inl"
 
 template <typename T>
 ExpressionTree<T> ExpressionTree<T>::simplified() const {
@@ -68,25 +69,11 @@ NodePtr<T> ExpressionTree<T>::simplify_node(NodePtr<T> const& node) const {
 					std::vector<NodePtr<T>> s_operands = { s_lhs, s_rhs };
 					return process_multiplication(s_operands);
 				}
+				case BinaryOp<T>::Op::Divide:
+					return process_division(s_lhs, s_rhs);
 				default:
 					break;
 				}
-
-				// NOTE: + - * already handled, this can only be a division!
-				if (auto const* c_lhs = std::get_if<Constant<T>>(&s_lhs->node_type)) { // 0 / x => 0
-					if (c_lhs->value == 0)
-						return s_lhs;
-				}
-				if (auto const* c_rhs = std::get_if<Constant<T>>(&s_rhs->node_type)) {
-					if (c_rhs->value == 1)
-						return s_lhs;
-				}
-				if (are_trees_identical(s_lhs, s_rhs))
-					return std::make_shared<const ExpressionNode<T>>(Constant<T>{ 1 });
-
-				if (s_lhs != n.lhs || s_rhs != n.rhs)
-					return std::make_shared<const ExpressionNode<T>>(BinaryOp<T>{ n.operation, s_lhs, s_rhs });
-
 			} else if constexpr (std::is_same_v<VT, NaryOp<T>>) {
 				std::vector<NodePtr<T>> s_operands;
 				s_operands.reserve(n.operands.size());

--- a/include/symbolic/expression_tree/simplify/division.inl
+++ b/include/symbolic/expression_tree/simplify/division.inl
@@ -1,0 +1,19 @@
+#include "scheduler.hpp"
+template <typename T>
+NodePtr<T> ExpressionTree<T>::process_division(NodePtr<T>& s_lhs, NodePtr<T>& s_rhs) const {
+	// NOTE: + - * already handled, this can only be a division!
+	auto const* c_lhs = std::get_if<Constant<T>>(&s_lhs->node_type);
+	auto const* c_rhs = std::get_if<Constant<T>>(&s_rhs->node_type);
+	if (c_lhs && c_rhs) { // constant folding
+		return std::make_shared<const ExpressionNode<T>>(Constant<T>{ c_lhs->value / c_rhs->value });
+	} else if (c_lhs && c_lhs->value == 0) {
+		return s_lhs;
+	} else if (c_rhs && c_rhs->value == 1) {
+		return s_lhs;
+	}
+
+	if (are_trees_identical(s_lhs, s_rhs))
+		return std::make_shared<const ExpressionNode<T>>(Constant<T>{ 1 });
+
+	return std::make_shared<const ExpressionNode<T>>(BinaryOp<T>{ BinaryOp<T>::Op::Divide, s_lhs, s_rhs });
+}

--- a/tests/compiled_expression.cpp
+++ b/tests/compiled_expression.cpp
@@ -1,0 +1,139 @@
+#include "gtest/gtest.h"
+#include "pauli.hpp"
+#include "symbolic/coefficient.hpp" // Includes all necessary headers
+#include <symbolic/expression_tree.hpp>
+#include <cmath> // For std::isinf, std::isnan
+#include <limits> // For infinity()
+
+// A test fixture to provide common symbolic variables for our tests
+class CompiledExpressionTest : public ::testing::Test {
+    protected:
+	using Symbolic = SymbolicCoefficient<coeff_t>;
+
+	Symbolic a{ "a" }, b{ "b" }, c{ "c" }, d{ "d" };
+	Symbolic x{ "x" }, y{ "y" }, z{ "z" };
+
+	// Helper function to encapsulate the core test logic:
+	// Compare the result of symbolic evaluation vs. compiled evaluation.
+	void VerifyCompilation(const Symbolic& expr, const std::unordered_map<std::string, coeff_t>& vars, coeff_t tolerance = 1e-9) {
+		auto tree = expr.get_expression_tree(); // simplified() is not called to test the compiler on raw trees
+
+		// 1. Get the "ground truth" result from the uncompiled tree
+		coeff_t expected = tree.evaluate(vars);
+
+		// 2. Compile and evaluate the new class
+		CompiledExpression<coeff_t> compiled_expr(tree);
+		coeff_t actual = compiled_expr.evaluate(vars);
+
+		// 3. Compare the results
+		EXPECT_NEAR(expected, actual, tolerance);
+	}
+};
+
+// --- I. Functional Tests ---
+
+TEST_F(CompiledExpressionTest, BasicAddition) { VerifyCompilation(x + y, { { "x", 2.5 }, { "y", -1.0 } }); }
+
+TEST_F(CompiledExpressionTest, BasicSubtraction) { VerifyCompilation(x - y, { { "x", 2.5 }, { "y", -1.0 } }); }
+
+TEST_F(CompiledExpressionTest, BasicMultiplication) { VerifyCompilation(x * y, { { "x", 2.5 }, { "y", -1.0 } }); }
+
+TEST_F(CompiledExpressionTest, BasicDivision) { VerifyCompilation(x / y, { { "x", 2.5 }, { "y", -1.0 } }); }
+
+TEST_F(CompiledExpressionTest, UnaryNegation) { VerifyCompilation(-x, { { "x", 123.45 } }); }
+
+TEST_F(CompiledExpressionTest, UnaryFunctions) {
+	VerifyCompilation(sin(x) + cos(y) - sqrt(z), { { "x", 0.5 }, { "y", -0.25 }, { "z", 16.0 } });
+}
+
+TEST_F(CompiledExpressionTest, OperatorPrecedence) {
+	VerifyCompilation(a + b * c, { { "a", 2 }, { "b", 3 }, { "c", 4 } }); // Should be 2 + 12 = 14
+}
+
+TEST_F(CompiledExpressionTest, ParenthesesOverridePrecedence) {
+	VerifyCompilation((a + b) * c, { { "a", 2 }, { "b", 3 }, { "c", 4 } }); // Should be 5 * 4 = 20
+}
+
+TEST_F(CompiledExpressionTest, ComplexMixedExpression) {
+	VerifyCompilation(a * b + c / d - sin(x), { { "a", 2 }, { "b", 3 }, { "c", 8 }, { "d", 4 }, { "x", 0 } });
+}
+
+TEST_F(CompiledExpressionTest, NaryAddition) {
+	VerifyCompilation(a + b + c + d + x, { { "a", 1 }, { "b", 2 }, { "c", 3 }, { "d", 4 }, { "x", 5 } });
+}
+
+TEST_F(CompiledExpressionTest, NaryMultiplication) {
+	VerifyCompilation(a * b * c * d * x, { { "a", 1 }, { "b", 2 }, { "c", 3 }, { "d", 4 }, { "x", 5 } });
+}
+
+// --- II. Tests for Compiler Optimizations ---
+
+TEST_F(CompiledExpressionTest, ConstantDeduplication) {
+	// 3.14 appears three times in the tree
+	VerifyCompilation((x * 3.14) + (y * 3.14) - 3.14, { { "x", 10 }, { "y", 20 } });
+}
+
+TEST_F(CompiledExpressionTest, VariableDeduplication) {
+	// x appears three times in the tree
+	VerifyCompilation((x * x) / sin(x) + x, { { "x", 0.8 } });
+}
+
+TEST_F(CompiledExpressionTest, CommonSubexpressionElimination) {
+	// The sub-tree (a * b + c) appears twice and should only be computed once.
+	auto sub_expr = a * b + c;
+	VerifyCompilation(sin(sub_expr) / sub_expr, { { "a", 2 }, { "b", 3 }, { "c", 4 } });
+}
+
+TEST_F(CompiledExpressionTest, ComplexRealisticExpression) {
+	// Tests nested functions and CSE on (y/z)
+	auto expr = sqrt(cos(x) * cos(x) + sin(x) * sin(x)) + (y / z) * (y / z);
+	VerifyCompilation(expr, { { "x", 0.7 }, { "y", 10.0 }, { "z", 2.0 } });
+}
+
+// --- III. Edge Case Tests ---
+
+TEST_F(CompiledExpressionTest, EmptyExpression) {
+	ExpressionTree<coeff_t> empty_tree;
+	CompiledExpression<coeff_t> compiled_expr(empty_tree);
+	EXPECT_EQ(compiled_expr.evaluate({}), 0.0);
+}
+
+TEST_F(CompiledExpressionTest, SingleConstant) { VerifyCompilation(Symbolic(42.0), {}); }
+
+TEST_F(CompiledExpressionTest, SingleVariable) { VerifyCompilation(x, { { "x", 123.0 } }); }
+
+TEST_F(CompiledExpressionTest, DeeplyNestedUnary) {
+	auto expr = cos(sin(sqrt(cos(sin(x)))));
+	VerifyCompilation(expr, { { "x", 0.9 } });
+}
+
+// --- IV. Numerical Edge Cases ---
+
+TEST_F(CompiledExpressionTest, DivisionByZero) {
+	auto expr = Symbolic(1.0) / x;
+	auto tree = expr.get_expression_tree();
+	CompiledExpression<coeff_t> compiled_expr(tree);
+
+	coeff_t result = compiled_expr.evaluate({ { "x", 0.0 } });
+	EXPECT_TRUE(std::isinf(result));
+}
+
+TEST_F(CompiledExpressionTest, SqrtOfNegative) {
+	auto expr = sqrt(x);
+	auto tree = expr.get_expression_tree();
+	CompiledExpression<coeff_t> compiled_expr(tree);
+
+	coeff_t result = compiled_expr.evaluate({ { "x", -1.0 } });
+	EXPECT_TRUE(std::isnan(result));
+}
+
+// --- V. Input Validation Edge Cases ---
+
+TEST_F(CompiledExpressionTest, ThrowsOnMissingVariable) {
+	auto expr = x + y;
+	auto tree = expr.get_expression_tree();
+	CompiledExpression<coeff_t> compiled_expr(tree);
+
+	// Expect std::invalid_argument or std::out_of_range depending on map::at vs find
+	EXPECT_THROW(compiled_expr.evaluate({ { "x", 1.0 } }), std::invalid_argument);
+}

--- a/tests/symbolic_coefficient.cpp
+++ b/tests/symbolic_coefficient.cpp
@@ -1,6 +1,7 @@
 #include "gtest/gtest.h"
 
 #include <cmath>
+#include <string>
 #include <symbolic/coefficient.hpp>
 
 using Sc = SymbolicCoefficient<float>;
@@ -242,4 +243,23 @@ TEST(SymbolicCoefficient, simplify_associativity_hard) {
 	EXPECT_EQ(x.to_string(), "((x * 2) * 3) * 2");
 	auto sx = x.simplified();
 	EXPECT_EQ(sx.to_string(), "12 * x");
+}
+
+TEST(SymbolicCoefficient, simplify_edge_case) {
+	Sc pi = 3.14159f;
+	pi  = pi / 2.f;
+	pi = -pi;
+	pi = cos(pi);
+	auto smp = pi.simplified();
+	auto converted = std::stof(smp.to_string());
+	EXPECT_NEAR(converted, 0.f, 1e-4f);
+}
+
+TEST(SymbolicCoefficient, simplify_edge_case2) {
+	Sc pi = 3.14159f / 2.f;
+	pi = -pi;
+	pi = cos(pi);
+	auto smp = pi.simplified();
+	auto converted = std::stof(smp.to_string());
+	EXPECT_NEAR(converted, 0.f, 1e-4f);
 }


### PR DESCRIPTION
Using the library proved that evaluating symbolic expressions was too slow, even in their simplified form.

This PR introduces `CompiledExpression` that are highly optimized, but static symbolic expression that can do nothing else but be evaluated.

Here are the benchmarks results:
| Benchmark              | ExpressionTree.evaluate | **Compiled**ExpressionTree.evaluate | Speedup |
|------------------------|-------------------------|-------------------------------------|---------|
| SymbolicMaxCutQAOAN4P1 | 498 ns                  | 153 ns                              | **3**   |
| SymbolicMaxCutQAOAN4P3 | 22730124 ns             | 95736 ns                            | **237** |

This PR also fixes constant folding for divisions.