### PR TITLE
Pauli axis rotation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ set(BENCHMARK OFF CACHE BOOL "Build benchmarks")
 set(TEST OFF CACHE BOOL "Build tests")
 
 project(ProPauli
-	VERSION 4.1.0
+	VERSION 5.0.0
 DESCRIPTION "Fast and efficient C++ library for Pauli Propagation"
 	LANGUAGES CXX)
 
@@ -85,6 +85,7 @@ if (TEST)
 	include(FetchContent)
 	FetchContent_Declare(
 		googletest
+		GIT_REPOSITORY https://github.com/google/googletest.git
 		GIT_TAG v1.17.0
 	)
 	# For Windows: Prevent overriding the parent project's compiler/linker settings
@@ -113,6 +114,7 @@ if (BENCHMARK)
 	include(FetchContent)
 	FetchContent_Declare(
 		googlebenchmark
+		GIT_REPOSITORY https://github.com/google/benchmark.git
 		GIT_TAG v1.9.4
 	)
 	set(BENCHMARK_ENABLE_TESTING OFF CACHE BOOL "Disable testing for Google Benchmark")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,10 +85,8 @@ if (TEST)
 	include(FetchContent)
 	FetchContent_Declare(
 		googletest
-		# Specify the commit you depend on and update it regularly.
-		URL https://github.com/google/googletest/archive/52eb8108c5bdec04579160ae17225d66034bd723.zip
-		DOWNLOAD_EXTRACT_TIMESTAMP true
-)
+		GIT_TAG v1.17.0
+	)
 	# For Windows: Prevent overriding the parent project's compiler/linker settings
 	set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 	FetchContent_MakeAvailable(googletest)
@@ -115,8 +113,7 @@ if (BENCHMARK)
 	include(FetchContent)
 	FetchContent_Declare(
 		googlebenchmark
-		URL https://github.com/google/benchmark/archive/refs/tags/v1.9.4.zip
-		DOWNLOAD_EXTRACT_TIMESTAMP true
+		GIT_TAG v1.9.4
 	)
 	set(BENCHMARK_ENABLE_TESTING OFF CACHE BOOL "Disable testing for Google Benchmark")
 	FetchContent_MakeAvailable(googlebenchmark)

--- a/benchmarks/observables.cpp
+++ b/benchmarks/observables.cpp
@@ -374,11 +374,32 @@ static void Observable_appy_amplitude_damping_z(benchmark::State& state) {
 	}
 }
 
+static void Observable_apply_rp_12times(benchmark::State& state) {
+	static constexpr coeff_t theta = 2.f;
+	std::vector<Pauli> H;
+	std::generate_n(std::back_inserter(H), state.range(0), [=]() { return random_pauli(); });
+	std::vector<Observable<coeff_t>> obses;
+	std::generate_n(std::back_inserter(obses), 1024, [&]() { return Observable{ random_pauli_string(state.range(0)) }; });
+
+	std::size_t i = 0;
+	for (auto _ : state) {
+		state.PauseTiming();
+		auto obs = obses[i];
+		i = (i + 1) % 1024;
+		state.ResumeTiming();
+
+		for (std::size_t j = 0; j < 12; ++j) {
+			obs.apply_rp(H, theta);
+		}
+	}
+}
+
 BENCHMARK(Observable_init_from_string)->Arg(1)->Arg(1024);
 BENCHMARK(Observable_apply_pauli)->Arg(1)->Arg(1024);
 BENCHMARK(Observable_apply_clifford)->Arg(1)->Arg(1024);
 BENCHMARK(Observable_apply_unital_noise)->Arg(1)->Arg(1024);
 BENCHMARK(Observable_apply_rz_once)->Arg(1)->Arg(1024);
+BENCHMARK(Observable_apply_rp_12times)->Arg(8)->Arg(64)->Arg(1024);
 BENCHMARK(Observable_apply_rz_ntimes)->Args({ 1024, 16 });
 BENCHMARK(Observable_ev_after_nrz)->Args({ 1024, 16 });
 BENCHMARK(Observable_merge_after_nrz)->Args({ 8, 16 })->Args({ 1024, 1 })->Args({ 1024, 8 });

--- a/benchmarks/observables.cpp
+++ b/benchmarks/observables.cpp
@@ -1,4 +1,5 @@
 #include "pauli.hpp"
+#include "pauli_axis.hpp"
 #include "policies/sequential.hpp"
 #include "truncate.hpp"
 #include <benchmark/benchmark.h>
@@ -376,8 +377,9 @@ static void Observable_appy_amplitude_damping_z(benchmark::State& state) {
 
 static void Observable_apply_rp_12times(benchmark::State& state) {
 	static constexpr coeff_t theta = 2.f;
-	std::vector<Pauli> H;
-	std::generate_n(std::back_inserter(H), state.range(0), [=]() { return random_pauli(); });
+	std::vector<Pauli> Hp;
+	std::generate_n(std::back_inserter(Hp), state.range(0), [=]() { return random_pauli(); });
+	PauliAxis<> H{Hp.begin(), Hp.end()};
 	std::vector<Observable<coeff_t>> obses;
 	std::generate_n(std::back_inserter(obses), 1024, [&]() { return Observable{ random_pauli_string(state.range(0)) }; });
 

--- a/include/circuit.hpp
+++ b/include/circuit.hpp
@@ -109,6 +109,7 @@ class Circuit {
 									 { "H", H },
 									 { "CX", Cx },
 									 { "RZ", Rz },
+									 { "RP", Rp },
 									 { "AMPLITUDEDAMPING", AmplitudeDamping },
 									 { "DEPOLARIZING", Depolarizing },
 									 { "DEPHASING", Dephasing } };
@@ -145,6 +146,10 @@ class Circuit {
 	void y(unsigned qubit) { add_operation(QGate::Y, qubit); }
 	void z(unsigned qubit) { add_operation(QGate::Z, qubit); }
 	void rz(unsigned qubit, Coefficient_t const& coeff) { add_operation(QGate::Rz, qubit, coeff); }
+	void rp(std::vector<Pauli> const& pauli_axis, Coefficient_t const& coeff) { add_operation(QGate::Rp, pauli_axis, coeff); }
+	void eiht(std::vector<Pauli> const& pauli_axis, Coefficient_t const& t) {
+		add_operation(QGate::Rp, pauli_axis, t * Coefficient_t{ 2 });
+	}
 
 	/**
 	 * @brief Runs the simulation on the circuit.
@@ -210,15 +215,16 @@ class Circuit {
 
 	template <typename ExecutionPolicy = DefaultExecutionPolicy>
 	auto expectation_value(std::vector<Observable<Coefficient_t>> const& target_observables,
-						     ExecutionPolicy&& policy = ExecutionPolicy{}) {
+			       ExecutionPolicy&& policy = ExecutionPolicy{}) {
 		using Policy_t = std::remove_cvref_t<decltype(policy)>;
 		return Policy_t::circuit_batched_evs(*this, target_observables);
 	}
 
 	template <typename ExecutionPolicy = DefaultExecutionPolicy>
-	std::pair<Coefficient_t, Coefficient_t> expectation_value(Observable<Coefficient_t> const& target_observable, ExecutionPolicy&& policy = ExecutionPolicy{}) {
+	std::pair<Coefficient_t, Coefficient_t> expectation_value(Observable<Coefficient_t> const& target_observable,
+								  ExecutionPolicy&& policy = ExecutionPolicy{}) {
 		auto res = run(target_observable, std::forward<ExecutionPolicy>(policy));
-		return {res.expectation_value(), res.truncate_error()};
+		return { res.expectation_value(), res.truncate_error() };
 	}
 
 	template <typename Input, IsVariant DynamicPolicy>
@@ -312,6 +318,14 @@ class Circuit {
 	void check_args(unsigned qubit, [[maybe_unused]] Real&& arg)
 		requires(std::is_floating_point_v<std::remove_cvref_t<Real>> || Symbolic<std::remove_cvref_t<Real>>) {
 		check_args(qubit);
+	}
+
+	template <typename Real>
+	void check_args(std::vector<Pauli> const& axis, [[maybe_unused]] Real&& arg)
+		requires(std::is_floating_point_v<std::remove_cvref_t<Real>> || Symbolic<std::remove_cvref_t<Real>>) {
+		if (axis.size() != nb_qubits()) {
+			throw std::invalid_argument("Axis length for Rp gate should match circuit size.");
+		}
 	}
 
 	/**

--- a/include/container/packed_pauli_term.inl
+++ b/include/container/packed_pauli_term.inl
@@ -368,7 +368,7 @@ class NonOwningPauliTermPacked {
 			output.set_coefficient(output.coefficient() * sin_theta);
 		}
 	}
-	void apply_rg(std::vector<Pauli> axis, T theta, NonOwningPauliTermPacked& output) {
+	void apply_rp(std::vector<Pauli> axis, T theta, NonOwningPauliTermPacked& output) {
 		assert(!commutes_with(axis));
 
 		const auto cos_teta = cos(theta);

--- a/include/container/packed_pauli_term.inl
+++ b/include/container/packed_pauli_term.inl
@@ -368,8 +368,7 @@ class NonOwningPauliTermPacked {
 			output.set_coefficient(output.coefficient() * sin_theta);
 		}
 	}
-	void apply_rg(unsigned qubit, std::vector<Pauli> axis, T theta, NonOwningPauliTermPacked& output) {
-		assert(qubit < size());
+	void apply_rg(std::vector<Pauli> axis, T theta, NonOwningPauliTermPacked& output) {
 		assert(!commutes_with(axis));
 
 		const auto cos_teta = cos(theta);
@@ -381,8 +380,8 @@ class NonOwningPauliTermPacked {
 		const auto len = output.size();
 		for (std::size_t i = 0; i < len; ++i) {
 			Pauli res_p = axis[i];
-			i_pow += res_p.multiply_right(output[i]);
-			output[i] = res_p;
+			i_pow += res_p.multiply_right(output.get_pauli(i));
+			output.set_pauli(i, res_p);
 		}
 
 		T const sign = (((i_pow % 4) + 4) % 4 == 2) ? T{-1} : T{1};

--- a/include/container/packed_pauli_term.inl
+++ b/include/container/packed_pauli_term.inl
@@ -372,24 +372,27 @@ class NonOwningPauliTermPacked {
 			output.set_coefficient(output.coefficient() * sin_theta);
 		}
 	}
-	void apply_rp(PauliAxis<> const& axis, T theta, NonOwningPauliTermPacked& output) {
-		assert(!commutes_with(axis.raw_bits()));
+	void apply_rp(std::vector<Underlying> const& axis_bytes, T theta, NonOwningPauliTermPacked& output) {
+		assert(!commutes_with(axis_bytes));
 
 		const auto cos_teta = cos(theta);
 		const auto sin_theta = sin(theta);
+		const auto old_coeff = coefficient();
 
-		set_coefficient(coefficient() * cos_teta);
+		set_coefficient(old_coeff * cos_teta);
 
 		int i_pow = 1;
-		const auto len = output.size();
-		for (std::size_t i = 0; i < len; ++i) {
-			Pauli res_p = axis[i];
-			i_pow += res_p.multiply_right(output.get_pauli(i));
-			output.set_pauli(i, res_p);
+		const auto nb_underlying = output.ptc.get().nb_underlying_per_pt;
+		std::size_t start_idx = idx * nb_underlying;
+		std::size_t output_idx = output.idx * nb_underlying;
+		for (std::size_t i = 0; i < nb_underlying; ++i) {
+			auto [result_byte, phase] = PauliBitwise::multiply_bytes(axis_bytes[i], ptc.get().raw_bits[start_idx + i]);
+			output.ptc.get().raw_bits[output_idx + i] = result_byte;
+			i_pow += phase;
 		}
 
 		T const sign = (((i_pow % 4) + 4) % 4 == 2) ? T{ -1 } : T{ 1 };
-		output.set_coefficient(output.coefficient() * sin_theta * sign);
+		output.set_coefficient(old_coeff * sin_theta * sign);
 	}
 	void apply_amplitude_damping_xy([[maybe_unused]] unsigned qubit, T p) {
 		assert(qubit < size());

--- a/include/container/packed_pauli_term.inl
+++ b/include/container/packed_pauli_term.inl
@@ -76,6 +76,14 @@ class ReadOnlyNonOwningPauliTermPacked {
 	 */
 	std::size_t phash() const noexcept { return ptc.get().fast_phash(idx); }
 
+	bool commutes_with(std::vector<Pauli> const& axis) const {
+		bool commutes = true;
+		for (std::size_t i = 0; i < size(); ++i) {
+			commutes ^= !get_pauli(i).commutes_with(axis[i]);
+		}
+		return commutes;
+	}
+
 	/** @name Comparison
 	 * @{
 	 */
@@ -230,6 +238,14 @@ class NonOwningPauliTermPacked {
 	 */
 	std::size_t phash() const noexcept { return ptc.get().fast_phash(idx); }
 
+	bool commutes_with(std::vector<Pauli> const& axis) const {
+		bool commutes = true;
+		for (std::size_t i = 0; i < size(); ++i) {
+			commutes ^= !get_pauli(i).commutes_with(axis[i]);
+		}
+		return commutes;
+	}
+	
 	/** @name Comparison
 	 * @{
 	 */
@@ -351,6 +367,26 @@ class NonOwningPauliTermPacked {
 			output.set_pauli(qubit, p_x);
 			output.set_coefficient(output.coefficient() * sin_theta);
 		}
+	}
+	void apply_rg(unsigned qubit, std::vector<Pauli> axis, T theta, NonOwningPauliTermPacked& output) {
+		assert(qubit < size());
+		assert(!commutes_with(axis));
+
+		const auto cos_teta = cos(theta);
+		const auto sin_theta = sin(theta);
+
+		set_coefficient(coefficient() * cos_teta);
+
+		int i_pow = 1;
+		const auto len = output.size();
+		for (std::size_t i = 0; i < len; ++i) {
+			Pauli res_p = axis[i];
+			i_pow += res_p.multiply_right(output[i]);
+			output[i] = res_p;
+		}
+
+		T const sign = (((i_pow % 4) + 4) % 4 == 2) ? T{-1} : T{1};
+		output.set_coefficient(output.coefficient() * sin_theta * sign);
 	}
 	void apply_amplitude_damping_xy([[maybe_unused]] unsigned qubit, T p) {
 		assert(qubit < size());

--- a/include/container/packed_pauli_term.inl
+++ b/include/container/packed_pauli_term.inl
@@ -76,12 +76,14 @@ class ReadOnlyNonOwningPauliTermPacked {
 	 */
 	std::size_t phash() const noexcept { return ptc.get().fast_phash(idx); }
 
-	bool commutes_with(std::vector<Pauli> const& axis) const {
-		bool commutes = true;
-		for (std::size_t i = 0; i < size(); ++i) {
-			commutes ^= !get_pauli(i).commutes_with(axis[i]);
+	bool commutes_with(std::vector<Underlying> const& axis_bytes) const {
+		const std::size_t start_idx = idx * ptc.get().nb_underlying_per_pt;
+		int total_anti_commuting = 0;
+		for (size_t i = 0; i < ptc.get().nb_underlying_per_pt; ++i) {
+			total_anti_commuting +=
+				PauliBitwise::count_anti_commuting_in_byte(axis_bytes[i], ptc.get().raw_bits[start_idx + i]);
 		}
-		return commutes;
+		return (total_anti_commuting % 2 == 0);
 	}
 
 	/** @name Comparison
@@ -238,14 +240,16 @@ class NonOwningPauliTermPacked {
 	 */
 	std::size_t phash() const noexcept { return ptc.get().fast_phash(idx); }
 
-	bool commutes_with(std::vector<Pauli> const& axis) const {
-		bool commutes = true;
-		for (std::size_t i = 0; i < size(); ++i) {
-			commutes ^= !get_pauli(i).commutes_with(axis[i]);
+	bool commutes_with(std::vector<Underlying> const& axis_bytes) const {
+		const std::size_t start_idx = idx * ptc.get().nb_underlying_per_pt;
+		int total_anti_commuting = 0;
+		for (size_t i = 0; i < ptc.get().nb_underlying_per_pt; ++i) {
+			total_anti_commuting +=
+				PauliBitwise::count_anti_commuting_in_byte(axis_bytes[i], ptc.get().raw_bits[start_idx + i]);
 		}
-		return commutes;
+		return (total_anti_commuting % 2 == 0);
 	}
-	
+
 	/** @name Comparison
 	 * @{
 	 */
@@ -368,8 +372,8 @@ class NonOwningPauliTermPacked {
 			output.set_coefficient(output.coefficient() * sin_theta);
 		}
 	}
-	void apply_rp(std::vector<Pauli> axis, T theta, NonOwningPauliTermPacked& output) {
-		assert(!commutes_with(axis));
+	void apply_rp(PauliAxis<> const& axis, T theta, NonOwningPauliTermPacked& output) {
+		assert(!commutes_with(axis.raw_bits()));
 
 		const auto cos_teta = cos(theta);
 		const auto sin_theta = sin(theta);
@@ -384,7 +388,7 @@ class NonOwningPauliTermPacked {
 			output.set_pauli(i, res_p);
 		}
 
-		T const sign = (((i_pow % 4) + 4) % 4 == 2) ? T{-1} : T{1};
+		T const sign = (((i_pow % 4) + 4) % 4 == 2) ? T{ -1 } : T{ 1 };
 		output.set_coefficient(output.coefficient() * sin_theta * sign);
 	}
 	void apply_amplitude_damping_xy([[maybe_unused]] unsigned qubit, T p) {

--- a/include/container/pauli_bitwise.hpp
+++ b/include/container/pauli_bitwise.hpp
@@ -1,0 +1,91 @@
+#ifndef PP_PAULI_BITWISE_HPP
+#define PP_PAULI_BITWISE_HPP
+
+#include <cstdint>
+#include <utility>
+#include <array>
+#include <bit> // For std::popcount (C++20)
+
+// This namespace assumes the 2-bit Pauli enum mapping:
+// I = 0 (0b00), X = 1 (0b01), Y = 2 (0b10), Z = 3 (0b11)
+
+namespace PauliBitwise
+{
+
+/**
+ * @brief A compile-time lookup table for the phase of a Pauli product (p1 * p2).
+ * The index is calculated as (p1 << 2) | p2.
+ * The value is the phase encoded as a power of i: 0 for +1, 1 for +i, -1 for -i.
+ */
+consteval auto init_phase_lut() {
+	std::array<int, 16> lut{};
+	// Products with phase +i
+	lut[(1 << 2) | 2] = 1; // XY = iZ
+	lut[(2 << 2) | 3] = 1; // YZ = iX
+	lut[(3 << 2) | 1] = 1; // ZX = iY
+	// Products with phase -i
+	lut[(2 << 2) | 1] = -1; // YX = -iZ
+	lut[(3 << 2) | 2] = -1; // ZY = -iX
+	lut[(1 << 2) | 3] = -1; // XZ = -iY
+	return lut;
+}
+
+static constexpr auto PHASE_LUT = init_phase_lut();
+
+/**
+ * @brief Counts the number of anti-commuting Pauli pairs within two packed bytes.
+ * This is a branchless function that processes 4 Pauli pairs simultaneously.
+ * @param b1 A byte containing 4 packed Paulis.
+ * @param b2 A byte containing 4 packed Paulis.
+ * @return The number of pairs (from 0 to 4) that anti-commute.
+ */
+inline constexpr int count_anti_commuting_in_byte(uint8_t b1, uint8_t b2) {
+	// A pair (p1, p2) anti-commutes if p1 != I, p2 != I, and p1 != p2.
+
+	// 1. Create a mask where each 2-bit chunk is 00 if the Pauli is I.
+	// Since I=0, the bytes themselves serve as these non-identity masks.
+	const uint8_t non_identity1 = b1;
+	const uint8_t non_identity2 = b2;
+
+	// 2. Create a mask where each 2-bit chunk is non-zero if p1 != p2.
+	const uint8_t different_paulis = b1 ^ b2;
+
+	// 3. For each 2-bit chunk, we need a 1-bit "truthiness" value.
+	// The expression `(p | (p >> 1)) & 0b01` converts a non-zero 2-bit Pauli `p` to `0b01`.
+	// We apply this to all 4 chunks in each byte simultaneously.
+	const uint8_t nz1_mask = ((non_identity1 >> 1) | non_identity1) & 0b01010101;
+	const uint8_t nz2_mask = ((non_identity2 >> 1) | non_identity2) & 0b01010101;
+	const uint8_t diff_mask = ((different_paulis >> 1) | different_paulis) & 0b01010101;
+
+	// 4. The low bit of a 2-bit chunk is 1 only if all three conditions were true for that pair.
+	const uint8_t anti_commute_mask = nz1_mask & nz2_mask & diff_mask;
+
+	// 5. The number of set bits in the final mask is the number of anti-commuting pairs.
+	return std::popcount(anti_commute_mask);
+}
+
+/**
+ * @brief Multiplies two bytes of packed Paulis (G * P).
+ * @param b_gen A byte of 4 generator Paulis (G).
+ * @param b_obs A byte of 4 observable Paulis (P).
+ * @return A pair containing the new byte (G*P) and the total phase power (sum of i powers).
+ */
+inline constexpr std::pair<uint8_t, int> multiply_bytes(uint8_t b_gen, uint8_t b_obs) {
+	// The resulting Pauli string is the bitwise XOR of the two bytes.
+	const uint8_t result_byte = b_gen ^ b_obs;
+	int total_phase = 0;
+
+	// Iterate through the 4 packed Paulis to look up and accumulate their product phase.
+	for (int i = 0; i < 4; ++i) {
+		const int shift = i * 2;
+		const uint8_t p_gen = (b_gen >> shift) & 0b11;
+		const uint8_t p_obs = (b_obs >> shift) & 0b11;
+		total_phase += PHASE_LUT[(p_gen << 2) | p_obs];
+	}
+
+	return { result_byte, total_phase };
+}
+
+} // namespace PauliBitwise
+
+#endif // PP_PAULI_BITWISE_HPP

--- a/include/noise_model.hpp
+++ b/include/noise_model.hpp
@@ -79,6 +79,14 @@ class NoiseModel {
 		apply_noise_after(qc, cg, qubit);
 	}
 
+	template <typename C, typename Real>
+	void apply_noise_after(C& qc, QGate cg, [[maybe_unused]] std::vector<Pauli> const& axis, [[maybe_unused]] Real theta)
+		requires(std::is_floating_point_v<Real> || Symbolic<Real>) {
+		for (std::size_t i = 0; i < qc.nb_qubits(); ++i) {
+			apply_noise_after(qc, cg, i);
+		}
+	}
+
 	/**
 	 * @brief Adds a unital noise channel to be applied after a specific gate type.
 	 * @param g The gate type after which the noise should be applied.

--- a/include/observable.hpp
+++ b/include/observable.hpp
@@ -191,34 +191,34 @@ class Observable {
 	}
 
 	template <IsNotVariant ExecutionPolicy = DefaultExecutionPolicy>
-	void apply_rg(std::vector<Pauli> const& axis, T theta, ExecutionPolicy&& policy = ExecutionPolicy{}) {
+	void apply_rp(std::vector<Pauli> const& axis, T theta, ExecutionPolicy&& policy = ExecutionPolicy{}) {
 		if (axis.size() != nb_qubits()) {
 			throw std::invalid_argument{ "Rotation axis length doesn't match observable size!" };
 		}
 		using Policy_t = std::remove_cvref_t<decltype(policy)>;
-		Policy_t::apply_rg(paulis_, axis, theta);
+		Policy_t::apply_rp(paulis_, axis, theta);
 	}
 
 	template <IsVariant DynamicPolicy>
-	void apply_rg(std::vector<Pauli> const& axis, T theta, DynamicPolicy&& rpol) {
-		return std::visit([&, this](auto const& pol) { return this->apply_rg(axis, theta, pol); }, rpol);
+	void apply_rp(std::vector<Pauli> const& axis, T theta, DynamicPolicy&& rpol) {
+		return std::visit([&, this](auto const& pol) { return this->apply_rp(axis, theta, pol); }, rpol);
 	}
 
 	template <typename Policy>
 	void apply_exp_iht(std::vector<Pauli> const& axis, T t, Policy&& pol) {
-		apply_rg(axis, t * 2, std::forward<Policy>(pol));
+		apply_rp(axis, t * 2, std::forward<Policy>(pol));
 	}
 
-		/**
-		 * @brief Applies an amplitude damping noise channel.
-		 * @param qubit The index of the qubit to apply the channel to.
-		 * @param pn The noise probability parameter.
-		 * @note This can be a **splitting** operation. If a term has a Z operator on the
-		 * target qubit, it will be split into two. If it has X or Y, its coefficient is
-		 * simply scaled. If it has I, there is no effect.
-		 */
-		template <IsNotVariant ExecutionPolicy = DefaultExecutionPolicy>
-		void apply_amplitude_damping(unsigned qubit, T pn, ExecutionPolicy&& policy = ExecutionPolicy{}) {
+	/**
+	 * @brief Applies an amplitude damping noise channel.
+	 * @param qubit The index of the qubit to apply the channel to.
+	 * @param pn The noise probability parameter.
+	 * @note This can be a **splitting** operation. If a term has a Z operator on the
+	 * target qubit, it will be split into two. If it has X or Y, its coefficient is
+	 * simply scaled. If it has I, there is no effect.
+	 */
+	template <IsNotVariant ExecutionPolicy = DefaultExecutionPolicy>
+	void apply_amplitude_damping(unsigned qubit, T pn, ExecutionPolicy&& policy = ExecutionPolicy{}) {
 		check_qubit(qubit);
 		using Policy_t = std::remove_cvref_t<decltype(policy)>;
 		Policy_t::apply_amplitude_damping(paulis_, qubit, pn);

--- a/include/observable.hpp
+++ b/include/observable.hpp
@@ -190,6 +190,21 @@ class Observable {
 		return std::visit([&, this](auto const& pol) { return this->apply_rz(qubit, theta, pol); }, rpol);
 	}
 
+	template <IsNotVariant ExecutionPolicy = DefaultExecutionPolicy>
+	void apply_rg(unsigned qubit, std::vector<Pauli> const& axis, T theta, ExecutionPolicy&& policy = ExecutionPolicy{}) {
+		if (axis.size() != nb_qubits()) {
+			throw std::invalid_argument{"Rotation axis length doesn't match observable size!"};
+		}
+		check_qubit(qubit);
+		using Policy_t = std::remove_cvref_t<decltype(policy)>;
+		Policy_t::apply_rg(paulis_, qubit, axis, theta);
+	}
+
+	template <IsVariant DynamicPolicy>
+	void apply_rg(unsigned qubit, std::vector<Pauli> const& axis, T theta, DynamicPolicy&& rpol) {
+		return std::visit([&, this](auto const& pol) { return this->apply_rg(qubit, axis, theta, pol); }, rpol);
+	}
+
 	/**
 	 * @brief Applies an amplitude damping noise channel.
 	 * @param qubit The index of the qubit to apply the channel to.

--- a/include/observable.hpp
+++ b/include/observable.hpp
@@ -191,18 +191,17 @@ class Observable {
 	}
 
 	template <IsNotVariant ExecutionPolicy = DefaultExecutionPolicy>
-	void apply_rg(unsigned qubit, std::vector<Pauli> const& axis, T theta, ExecutionPolicy&& policy = ExecutionPolicy{}) {
+	void apply_rg(std::vector<Pauli> const& axis, T theta, ExecutionPolicy&& policy = ExecutionPolicy{}) {
 		if (axis.size() != nb_qubits()) {
 			throw std::invalid_argument{"Rotation axis length doesn't match observable size!"};
 		}
-		check_qubit(qubit);
 		using Policy_t = std::remove_cvref_t<decltype(policy)>;
-		Policy_t::apply_rg(paulis_, qubit, axis, theta);
+		Policy_t::apply_rg(paulis_, axis, theta);
 	}
 
 	template <IsVariant DynamicPolicy>
-	void apply_rg(unsigned qubit, std::vector<Pauli> const& axis, T theta, DynamicPolicy&& rpol) {
-		return std::visit([&, this](auto const& pol) { return this->apply_rg(qubit, axis, theta, pol); }, rpol);
+	void apply_rg(std::vector<Pauli> const& axis, T theta, DynamicPolicy&& rpol) {
+		return std::visit([&, this](auto const& pol) { return this->apply_rg(axis, theta, pol); }, rpol);
 	}
 
 	/**

--- a/include/observable.hpp
+++ b/include/observable.hpp
@@ -193,7 +193,7 @@ class Observable {
 	template <IsNotVariant ExecutionPolicy = DefaultExecutionPolicy>
 	void apply_rg(std::vector<Pauli> const& axis, T theta, ExecutionPolicy&& policy = ExecutionPolicy{}) {
 		if (axis.size() != nb_qubits()) {
-			throw std::invalid_argument{"Rotation axis length doesn't match observable size!"};
+			throw std::invalid_argument{ "Rotation axis length doesn't match observable size!" };
 		}
 		using Policy_t = std::remove_cvref_t<decltype(policy)>;
 		Policy_t::apply_rg(paulis_, axis, theta);
@@ -204,16 +204,21 @@ class Observable {
 		return std::visit([&, this](auto const& pol) { return this->apply_rg(axis, theta, pol); }, rpol);
 	}
 
-	/**
-	 * @brief Applies an amplitude damping noise channel.
-	 * @param qubit The index of the qubit to apply the channel to.
-	 * @param pn The noise probability parameter.
-	 * @note This can be a **splitting** operation. If a term has a Z operator on the
-	 * target qubit, it will be split into two. If it has X or Y, its coefficient is
-	 * simply scaled. If it has I, there is no effect.
-	 */
-	template <IsNotVariant ExecutionPolicy = DefaultExecutionPolicy>
-	void apply_amplitude_damping(unsigned qubit, T pn, ExecutionPolicy&& policy = ExecutionPolicy{}) {
+	template <typename Policy>
+	void apply_exp_iht(std::vector<Pauli> const& axis, T t, Policy&& pol) {
+		apply_rg(axis, t * 2, std::forward<Policy>(pol));
+	}
+
+		/**
+		 * @brief Applies an amplitude damping noise channel.
+		 * @param qubit The index of the qubit to apply the channel to.
+		 * @param pn The noise probability parameter.
+		 * @note This can be a **splitting** operation. If a term has a Z operator on the
+		 * target qubit, it will be split into two. If it has X or Y, its coefficient is
+		 * simply scaled. If it has I, there is no effect.
+		 */
+		template <IsNotVariant ExecutionPolicy = DefaultExecutionPolicy>
+		void apply_amplitude_damping(unsigned qubit, T pn, ExecutionPolicy&& policy = ExecutionPolicy{}) {
 		check_qubit(qubit);
 		using Policy_t = std::remove_cvref_t<decltype(policy)>;
 		Policy_t::apply_amplitude_damping(paulis_, qubit, pn);
@@ -331,13 +336,9 @@ class Observable {
 		return ret;
 	}
 
-	T const& truncate_error() const {
-		return error_truncate;
-	}
+	T const& truncate_error() const { return error_truncate; }
 
-	void set_truncate_error(T const& new_error) {
-		error_truncate = new_error;
-	}
+	void set_truncate_error(T const& new_error) { error_truncate = new_error; }
 
 	friend bool operator==(Observable const& lhs, Observable const& rhs) {
 		return lhs.size() == rhs.size() && lhs.paulis_ == rhs.paulis_;

--- a/include/observable.hpp
+++ b/include/observable.hpp
@@ -12,6 +12,7 @@
  */
 
 #include "pauli.hpp"
+#include "pauli_axis.hpp"
 #include "pauli_term.hpp"
 #include "pauli_term_container.hpp"
 #include "symbolic/coefficient.hpp"
@@ -191,8 +192,8 @@ class Observable {
 	}
 
 	template <IsNotVariant ExecutionPolicy = DefaultExecutionPolicy>
-	void apply_rp(std::vector<Pauli> const& axis, T theta, ExecutionPolicy&& policy = ExecutionPolicy{}) {
-		if (axis.size() != nb_qubits()) {
+	void apply_rp(PauliAxis<> const& axis, T theta, ExecutionPolicy&& policy = ExecutionPolicy{}) {
+		if (axis.nb_qubits() != nb_qubits()) {
 			throw std::invalid_argument{ "Rotation axis length doesn't match observable size!" };
 		}
 		using Policy_t = std::remove_cvref_t<decltype(policy)>;
@@ -200,13 +201,8 @@ class Observable {
 	}
 
 	template <IsVariant DynamicPolicy>
-	void apply_rp(std::vector<Pauli> const& axis, T theta, DynamicPolicy&& rpol) {
+	void apply_rp(PauliAxis<> const& axis, T theta, DynamicPolicy&& rpol) {
 		return std::visit([&, this](auto const& pol) { return this->apply_rp(axis, theta, pol); }, rpol);
-	}
-
-	template <typename Policy>
-	void apply_exp_iht(std::vector<Pauli> const& axis, T t, Policy&& pol) {
-		apply_rp(axis, t * 2, std::forward<Policy>(pol));
 	}
 
 	/**

--- a/include/pauli.hpp
+++ b/include/pauli.hpp
@@ -33,11 +33,10 @@ consteval std::array<char, static_cast<std::size_t>(Pauli_enum::Count)> init_pau
 	return ret;
 }
 
-consteval std::array<std::array<Pauli_enum, static_cast<std::size_t>(Clifford_Gates_1Q::Count)>,
-		     static_cast<std::size_t>(Pauli_enum::Count)>
-init_clifford_array_map() {
-	std::array<std::array<Pauli_enum, static_cast<std::size_t>(Clifford_Gates_1Q::Count)>,
-		   static_cast<std::size_t>(Pauli_enum::Count)>
+consteval
+	std::array<std::array<Pauli_enum, static_cast<std::size_t>(Clifford_Gates_1Q::Count)>, static_cast<std::size_t>(Pauli_enum::Count)>
+	init_clifford_array_map() {
+	std::array<std::array<Pauli_enum, static_cast<std::size_t>(Clifford_Gates_1Q::Count)>, static_cast<std::size_t>(Pauli_enum::Count)>
 		ret;
 	// H Gate
 	ret[std::to_underlying(Pauli_enum::I)][std::to_underlying(Clifford_Gates_1Q::H)] = Pauli_enum::I;
@@ -49,12 +48,9 @@ init_clifford_array_map() {
 }
 
 template <typename T>
-consteval std::array<std::array<T, static_cast<std::size_t>(Clifford_Gates_1Q::Count)>,
-		     static_cast<std::size_t>(Pauli_enum::Count)>
+consteval std::array<std::array<T, static_cast<std::size_t>(Clifford_Gates_1Q::Count)>, static_cast<std::size_t>(Pauli_enum::Count)>
 init_clifford_array_coeff() {
-	std::array<std::array<T, static_cast<std::size_t>(Clifford_Gates_1Q::Count)>,
-		   static_cast<std::size_t>(Pauli_enum::Count)>
-		ret;
+	std::array<std::array<T, static_cast<std::size_t>(Clifford_Gates_1Q::Count)>, static_cast<std::size_t>(Pauli_enum::Count)> ret;
 	// H Gate
 	ret[std::to_underlying(Pauli_enum::I)][std::to_underlying(Clifford_Gates_1Q::H)] = T{ 1 };
 	ret[std::to_underlying(Pauli_enum::X)][std::to_underlying(Clifford_Gates_1Q::H)] = T{ 1 };
@@ -65,12 +61,9 @@ init_clifford_array_coeff() {
 }
 
 template <typename T>
-consteval std::array<std::array<T, static_cast<std::size_t>(Pauli_gates::Count)>,
-		     static_cast<std::size_t>(Pauli_enum::Count)>
+consteval std::array<std::array<T, static_cast<std::size_t>(Pauli_gates::Count)>, static_cast<std::size_t>(Pauli_enum::Count)>
 init_pauli_array_coeff() {
-	std::array<std::array<T, static_cast<std::size_t>(Pauli_gates::Count)>,
-		   static_cast<std::size_t>(Pauli_enum::Count)>
-		ret;
+	std::array<std::array<T, static_cast<std::size_t>(Pauli_gates::Count)>, static_cast<std::size_t>(Pauli_enum::Count)> ret;
 	// I Gate
 	ret[std::to_underlying(Pauli_enum::I)][std::to_underlying(Pauli_gates::I)] = T{ 1 };
 	ret[std::to_underlying(Pauli_enum::X)][std::to_underlying(Pauli_gates::I)] = T{ 1 };
@@ -99,9 +92,7 @@ consteval std::array<std::array<std::pair<Pauli_enum, Pauli_enum>, static_cast<s
 		     static_cast<std::size_t>(Pauli_enum::Count)>
 init_cx_array_map() {
 	using enum Pauli_enum;
-	std::array<std::array<std::pair<Pauli_enum, Pauli_enum>, static_cast<std::size_t>(Count)>,
-		   static_cast<std::size_t>(Count)>
-		ret;
+	std::array<std::array<std::pair<Pauli_enum, Pauli_enum>, static_cast<std::size_t>(Count)>, static_cast<std::size_t>(Count)> ret;
 	ret[std::to_underlying(I)][std::to_underlying(I)] = { I, I };
 	ret[std::to_underlying(I)][std::to_underlying(X)] = { I, X };
 	ret[std::to_underlying(I)][std::to_underlying(Y)] = { Z, Y };
@@ -126,12 +117,9 @@ init_cx_array_map() {
 }
 
 template <typename T>
-consteval std::array<std::array<T, static_cast<std::size_t>(UnitalNoise::Count)>,
-		     static_cast<std::size_t>(Pauli_enum::Count)>
+consteval std::array<std::array<T, static_cast<std::size_t>(UnitalNoise::Count)>, static_cast<std::size_t>(Pauli_enum::Count)>
 init_unital_noise_array_coeff() {
-	std::array<std::array<T, static_cast<std::size_t>(UnitalNoise::Count)>,
-		   static_cast<std::size_t>(Pauli_enum::Count)>
-		ret;
+	std::array<std::array<T, static_cast<std::size_t>(UnitalNoise::Count)>, static_cast<std::size_t>(Pauli_enum::Count)> ret;
 	// Depolarizing
 	ret[std::to_underlying(Pauli_enum::I)][std::to_underlying(UnitalNoise::Depolarizing)] = T{ 0 };
 	ret[std::to_underlying(Pauli_enum::X)][std::to_underlying(UnitalNoise::Depolarizing)] = T{ 1 };
@@ -146,17 +134,48 @@ init_unital_noise_array_coeff() {
 	return ret;
 }
 
+consteval std::array<std::array<Pauli_enum, static_cast<std::size_t>(Pauli_enum::Count)>, static_cast<std::size_t>(Pauli_enum::Count)>
+init_pauli_product_map() {
+	using enum Pauli_enum;
+	std::array<std::array<Pauli_enum, static_cast<std::size_t>(Count)>, static_cast<std::size_t>(Count)> ret{};
+
+	// Row-major: [p1][p2] -> p1 * p2
+	ret[std::to_underlying(I)] = { I, X, Y, Z };
+	ret[std::to_underlying(X)] = { X, I, Z, Y };
+	ret[std::to_underlying(Y)] = { Y, Z, I, X };
+	ret[std::to_underlying(Z)] = { Z, Y, X, I };
+	return ret;
+}
+
+consteval std::array<std::array<int, static_cast<std::size_t>(Pauli_enum::Count)>, static_cast<std::size_t>(Pauli_enum::Count)>
+init_pauli_product_phase_map() {
+	using enum Pauli_enum;
+	std::array<std::array<int, static_cast<std::size_t>(Count)>, static_cast<std::size_t>(Count)> ret{};
+
+	// Phase encoded as power of i: 0 for 1, 1 for i, -1 for -i
+	// Row-major: [p1][p2] -> phase(p1 * p2)
+	// Products with I or with self have phase 1 (i^0)
+	ret[std::to_underlying(X)][std::to_underlying(Y)] = 1; // XY = iZ
+	ret[std::to_underlying(Y)][std::to_underlying(X)] = -1; // YX = -iZ
+	ret[std::to_underlying(Y)][std::to_underlying(Z)] = 1; // YZ = iX
+	ret[std::to_underlying(Z)][std::to_underlying(Y)] = -1; // ZY = -iX
+	ret[std::to_underlying(Z)][std::to_underlying(X)] = 1; // ZX = iY
+	ret[std::to_underlying(X)][std::to_underlying(Z)] = -1; // XZ = -iY
+	return ret;
+}
+
 static constexpr auto pauli_char_map = init_pauli_str_map();
 static constexpr auto clifford_gates_map = init_clifford_array_map();
 static constexpr auto clifford_gates_coeff = init_clifford_array_coeff<coeff_t>();
 static constexpr auto pauli_gates_coeff = init_pauli_array_coeff<coeff_t>();
 static constexpr auto cx_map = init_cx_array_map();
 static constexpr auto unital_noise_map_coeff = init_unital_noise_array_coeff<coeff_t>();
+static constexpr auto pauli_product_map = init_pauli_product_map();
+static constexpr auto pauli_product_phase_map = init_pauli_product_phase_map();
 
 enum class QGate : array_underlying_type { I, X, Y, Z, H, Rz, Cx, AmplitudeDamping, Depolarizing, Dephasing, Count };
-static_assert(std::to_underlying(QGate::Count) ==
-	      (std::to_underlying(Pauli_gates::Count) + std::to_underlying(Clifford_Gates_1Q::Count) +
-	       std::to_underlying(UnitalNoise::Count) + 1 + 1 + 1));
+static_assert(std::to_underlying(QGate::Count) == (std::to_underlying(Pauli_gates::Count) + std::to_underlying(Clifford_Gates_1Q::Count) +
+						   std::to_underlying(UnitalNoise::Count) + 1 + 1 + 1));
 
 /**
  * @brief Represents a single Pauli operator (I, X, Y, or Z).
@@ -237,9 +256,7 @@ class Pauli {
 	 * @param p The other Pauli operator.
 	 * @return True if they commute, false otherwise.
 	 */
-	bool commutes_with(Pauli p) const {
-		return pauli_gates_coeff[std::to_underlying(p_)][std::to_underlying(p.p_)] > 0;
-	}
+	bool commutes_with(Pauli p) const { return pauli_gates_coeff[std::to_underlying(p_)][std::to_underlying(p.p_)] > 0; }
 
 	/**
 	 * @brief Calculates the Pauli weight of the operator.
@@ -252,9 +269,7 @@ class Pauli {
 	 * @param g The Pauli gate to apply.
 	 * @return A coefficient (+1 or -1) resulting from the application. The operator itself is not modified.
 	 */
-	coeff_t apply_pauli(Pauli_gates g) const {
-		return pauli_gates_coeff[std::to_underlying(p_)][std::to_underlying(g)];
-	}
+	coeff_t apply_pauli(Pauli_gates g) const { return pauli_gates_coeff[std::to_underlying(p_)][std::to_underlying(g)]; }
 
 	/**
 	 * @brief Applies a unital noise channel to this operator.
@@ -288,10 +303,22 @@ class Pauli {
 		target.p_ = res.second;
 
 		// map ? map here (based on condition, 2 elems map) implies 2.57ns => 3.73ns
-		return (p_ == Pauli_enum::X && target.p_ == Pauli_enum::Z) ||
-				       (p_ == Pauli_enum::Y && target.p_ == Pauli_enum::Y) ?
+		return (p_ == Pauli_enum::X && target.p_ == Pauli_enum::Z) || (p_ == Pauli_enum::Y && target.p_ == Pauli_enum::Y) ?
 			       coeff_t{ -1 } :
 			       coeff_t{ 1 };
+	}
+
+	/**
+	 * @brief Computes the algebraic product with another Pauli, modifying this one in place.
+	 * this -> this * other
+	 * @param other The Pauli operator to multiply by.
+	 * @return The phase of the product, encoded as a power of i (1 for i, -1 for -i, 0 for 1).
+	 */
+	int multiply_right(Pauli const& other) {
+		auto const p1 = std::to_underlying(p_);
+		auto const p2 = std::to_underlying(other.p_);
+		p_ = pauli_product_map[p1][p2];
+		return pauli_product_phase_map[p1][p2];
 	}
 
 	/**

--- a/include/pauli.hpp
+++ b/include/pauli.hpp
@@ -173,9 +173,9 @@ static constexpr auto unital_noise_map_coeff = init_unital_noise_array_coeff<coe
 static constexpr auto pauli_product_map = init_pauli_product_map();
 static constexpr auto pauli_product_phase_map = init_pauli_product_phase_map();
 
-enum class QGate : array_underlying_type { I, X, Y, Z, H, Rz, Cx, AmplitudeDamping, Depolarizing, Dephasing, Count };
+enum class QGate : array_underlying_type { I, X, Y, Z, H, Rz, Rp, Cx, AmplitudeDamping, Depolarizing, Dephasing, Count };
 static_assert(std::to_underlying(QGate::Count) == (std::to_underlying(Pauli_gates::Count) + std::to_underlying(Clifford_Gates_1Q::Count) +
-						   std::to_underlying(UnitalNoise::Count) + 1 + 1 + 1));
+						   std::to_underlying(UnitalNoise::Count) + 1 + 1 + 1 + 1));
 
 /**
  * @brief Represents a single Pauli operator (I, X, Y, or Z).

--- a/include/pauli_axis.hpp
+++ b/include/pauli_axis.hpp
@@ -1,0 +1,60 @@
+#ifndef PP_INCLUDE_PAULI_AXIS_HPP
+#define PP_INCLUDE_PAULI_AXIS_HPP
+
+#include "container/bit_operations.hpp"
+#include "pauli.hpp"
+
+#include <cstdint>
+#include <vector>
+#include <cassert>
+
+template <typename Underlying = std::uint8_t>
+class PauliAxis {
+	std::vector<Underlying> paulis;
+	std::size_t qubits; ///< The number of qubits for all terms in the container.
+	static constexpr Underlying BITS_PER_PAULI = 2;
+	static_assert(1 << BITS_PER_PAULI == static_cast<Underlying>(Pauli_enum::Count));
+	static constexpr Underlying MASK = compute_mask<Underlying>(BITS_PER_PAULI);
+	static constexpr Underlying PAULIS_PER_UNDERLYING = (sizeof(Underlying) * 8) / BITS_PER_PAULI;
+
+    public:
+	template <typename Iterator>
+	PauliAxis(Iterator begin, Iterator end) : qubits(std::distance(begin, end)) {
+		auto nb_underlying = qubits / PAULIS_PER_UNDERLYING;
+		if (qubits % PAULIS_PER_UNDERLYING > 0) {
+			nb_underlying++;
+		}
+		paulis.resize(nb_underlying, 0);
+
+		for (std::size_t i = 0; begin != end; ++begin, ++i) {
+			const std::size_t uidx = i / PAULIS_PER_UNDERLYING;
+			const std::size_t midx = i % PAULIS_PER_UNDERLYING;
+			const auto casted = static_cast<Underlying>(static_cast<Pauli_enum>(*begin));
+			const auto mask = (casted << (midx * BITS_PER_PAULI));
+			paulis[uidx] |= mask;
+		}
+	}
+
+	template <typename Container>
+	PauliAxis(Container&& container) : PauliAxis(container.begin(), container.end()) {}
+
+	PauliAxis() = default;
+	PauliAxis(PauliAxis const&) = default;
+	PauliAxis(PauliAxis&&) noexcept = default;
+	PauliAxis& operator=(PauliAxis const&) = default;
+	PauliAxis& operator=(PauliAxis&&) noexcept = default;
+
+	std::vector<Underlying> const& raw_bits() const { return paulis; }
+
+	std::size_t nb_qubits() const { return qubits; }
+
+	Pauli operator[](std::size_t const& idx) const {
+		assert(idx < nb_qubits());
+		const std::size_t uidx = idx / PAULIS_PER_UNDERLYING;
+		const std::size_t midx = idx % PAULIS_PER_UNDERLYING;
+		const Underlying masked = paulis[uidx] & (MASK << (midx * BITS_PER_PAULI));
+		return Pauli(static_cast<Pauli_enum>(masked >> (midx * BITS_PER_PAULI)));
+	}
+};
+
+#endif

--- a/include/pauli_term_container.hpp
+++ b/include/pauli_term_container.hpp
@@ -18,7 +18,9 @@
 #include "pauli.hpp"
 #include "pauli_term.hpp"
 #include "container/bit_operations.hpp"
+#include "container/pauli_bitwise.hpp"
 #include "adapter.hpp"
+#include "pauli_axis.hpp"
 #include "symbolic/coefficient.hpp"
 
 #include <algorithm>
@@ -140,6 +142,7 @@ class PauliTermContainer {
 	}
 
     public:
+	using Underlying_type = Underlying;
 	/** @name Constructors
 	 * @{
 	 */

--- a/include/policies/openmp.hpp
+++ b/include/policies/openmp.hpp
@@ -3,6 +3,7 @@
 
 #include "container/bit_operations.hpp"
 #include "pauli.hpp"
+#include "pauli_axis.hpp"
 #include "policies/sequential.hpp"
 #include "symbolic/coefficient.hpp"
 #include <cmath>
@@ -272,7 +273,7 @@ struct OpenMPPolicy {
 	}
 
 	template <typename PTC, typename T>
-	inline static void apply_rp(PTC& paulis, std::vector<Pauli> const& axis, T theta) {
+	inline static void apply_rp(PTC& paulis, PauliAxis<> const& axis, T theta) {
 		const auto nb_terms = paulis.nb_terms();
 
 		std::vector<std::size_t> allocated_per_thread(omp_get_max_threads(), 0);
@@ -285,7 +286,7 @@ struct OpenMPPolicy {
 			// compute number of required nb_term
 			#pragma omp for reduction(+ : total_to_allocate) schedule(static)
 			for (std::size_t i = 0; i < nb_terms; ++i) {
-				if (!paulis[i].commutes_with(axis)) {
+				if (!paulis[i].commutes_with(axis.raw_bits())) {
 					allocated_per_thread[tid]++;
 					total_to_allocate++;
 				}
@@ -306,7 +307,7 @@ struct OpenMPPolicy {
 			#pragma omp for schedule(static)
 			for (std::size_t i = 0; i < nb_terms; ++i) {
 				auto p = paulis[i];
-				if (!paulis[i].commutes_with(axis)) {
+				if (!paulis[i].commutes_with(axis.raw_bits())) {
 					const auto tmp_pt_idx = start_idx + k_idx;
 					auto new_path = paulis[tmp_pt_idx];
 					new_path.fast_copy_content(p);

--- a/include/policies/openmp.hpp
+++ b/include/policies/openmp.hpp
@@ -272,7 +272,7 @@ struct OpenMPPolicy {
 	}
 
 	template <typename PTC, typename T>
-	inline static void apply_rg(PTC& paulis, std::vector<Pauli> const& axis, unsigned qubit, T theta) {
+	inline static void apply_rg(PTC& paulis, std::vector<Pauli> const& axis, T theta) {
 		const auto nb_terms = paulis.nb_terms();
 
 		std::vector<std::size_t> allocated_per_thread(omp_get_max_threads(), 0);
@@ -306,11 +306,11 @@ struct OpenMPPolicy {
 			#pragma omp for schedule(static)
 			for (std::size_t i = 0; i < nb_terms; ++i) {
 				auto p = paulis[i];
-				if (!paulis[i].commutes_with(p_z)) {
+				if (!paulis[i].commutes_with(axis)) {
 					const auto tmp_pt_idx = start_idx + k_idx;
 					auto new_path = paulis[tmp_pt_idx];
 					new_path.fast_copy_content(p);
-					p.apply_rg(qubit, axis, theta, new_path);
+					p.apply_rg(axis, theta, new_path);
 					k_idx++;
 				}
 			}

--- a/include/policies/openmp.hpp
+++ b/include/policies/openmp.hpp
@@ -272,7 +272,7 @@ struct OpenMPPolicy {
 	}
 
 	template <typename PTC, typename T>
-	inline static void apply_rg(PTC& paulis, std::vector<Pauli> const& axis, T theta) {
+	inline static void apply_rp(PTC& paulis, std::vector<Pauli> const& axis, T theta) {
 		const auto nb_terms = paulis.nb_terms();
 
 		std::vector<std::size_t> allocated_per_thread(omp_get_max_threads(), 0);
@@ -310,7 +310,7 @@ struct OpenMPPolicy {
 					const auto tmp_pt_idx = start_idx + k_idx;
 					auto new_path = paulis[tmp_pt_idx];
 					new_path.fast_copy_content(p);
-					p.apply_rg(axis, theta, new_path);
+					p.apply_rp(axis, theta, new_path);
 					k_idx++;
 				}
 			}

--- a/include/policies/openmp.hpp
+++ b/include/policies/openmp.hpp
@@ -271,6 +271,52 @@ struct OpenMPPolicy {
 		}
 	}
 
+	template <typename PTC, typename T>
+	inline static void apply_rg(PTC& paulis, std::vector<Pauli> const& axis, unsigned qubit, T theta) {
+		const auto nb_terms = paulis.nb_terms();
+
+		std::vector<std::size_t> allocated_per_thread(omp_get_max_threads(), 0);
+		std::size_t total_to_allocate = 0;
+
+		#pragma omp parallel shared(allocated_per_thread)
+		{
+			auto tid = omp_get_thread_num();
+
+			// compute number of required nb_term
+			#pragma omp for reduction(+ : total_to_allocate) schedule(static)
+			for (std::size_t i = 0; i < nb_terms; ++i) {
+				if (!paulis[i].commutes_with(axis)) {
+					allocated_per_thread[tid]++;
+					total_to_allocate++;
+				}
+			}
+
+			// pre-alloc is mandatory to not invalidate terms while allocating
+			#pragma omp single
+			paulis._batch_allocate(total_to_allocate);
+
+			// get start_idx by computing sum of previous elements
+			std::size_t start_idx = nb_terms;
+			for (int k = 0; k < tid; ++k) {
+				start_idx += allocated_per_thread[k];
+			}
+
+			std::size_t k_idx = 0; // allocated index
+
+			#pragma omp for schedule(static)
+			for (std::size_t i = 0; i < nb_terms; ++i) {
+				auto p = paulis[i];
+				if (!paulis[i].commutes_with(p_z)) {
+					const auto tmp_pt_idx = start_idx + k_idx;
+					auto new_path = paulis[tmp_pt_idx];
+					new_path.fast_copy_content(p);
+					p.apply_rg(qubit, axis, theta, new_path);
+					k_idx++;
+				}
+			}
+		}
+	}
+
 	template <typename PTC>
 	inline static auto expectation_value(PTC const& paulis) -> decltype(paulis[0].expectation_value()) {
 		using Coeff_t = std::remove_cvref_t<decltype(paulis[0].expectation_value())>;

--- a/include/policies/openmp.hpp
+++ b/include/policies/openmp.hpp
@@ -310,8 +310,7 @@ struct OpenMPPolicy {
 				if (!paulis[i].commutes_with(axis.raw_bits())) {
 					const auto tmp_pt_idx = start_idx + k_idx;
 					auto new_path = paulis[tmp_pt_idx];
-					new_path.fast_copy_content(p);
-					p.apply_rp(axis, theta, new_path);
+					p.apply_rp(axis.raw_bits(), theta, new_path);
 					k_idx++;
 				}
 			}

--- a/include/policies/sequential.hpp
+++ b/include/policies/sequential.hpp
@@ -155,7 +155,7 @@ struct SequentialPolicy {
 	}
 
 	template <typename PTC, typename T>
-	inline static void apply_rg(PTC& paulis, std::vector<Pauli> const& axis, T theta) {
+	inline static void apply_rp(PTC& paulis, std::vector<Pauli> const& axis, T theta) {
 		const auto nb_terms = paulis.nb_terms();
 
 		// compute number of required nb_term
@@ -176,7 +176,7 @@ struct SequentialPolicy {
 				const auto tmp_pt_idx = nb_terms + k_idx;
 				auto new_path = paulis[tmp_pt_idx];
 				new_path.fast_copy_content(p);
-				p.apply_rg(axis, theta, new_path);
+				p.apply_rp(axis, theta, new_path);
 				k_idx++;
 			}
 		}

--- a/include/policies/sequential.hpp
+++ b/include/policies/sequential.hpp
@@ -154,6 +154,34 @@ struct SequentialPolicy {
 		}
 	}
 
+	template <typename PTC, typename T>
+	inline static void apply_rg(PTC& paulis, std::vector<Pauli> const& axis, unsigned qubit, T theta) {
+		const auto nb_terms = paulis.nb_terms();
+
+		// compute number of required nb_term
+		std::size_t total_to_allocate = 0;
+		for (std::size_t i = 0; i < nb_terms; ++i) {
+			if (!paulis[i].commutes_with(axis)) {
+				total_to_allocate++;
+			}
+		}
+
+		// pre-alloc is mandatory to not invalidate terms while allocating
+		paulis._batch_allocate(total_to_allocate);
+
+		std::size_t k_idx = 0; // allocated index
+		for (std::size_t i = 0; i < nb_terms; ++i) {
+			auto p = paulis[i];
+			if (!paulis[i].commutes_with(axis)) {
+				const auto tmp_pt_idx = nb_terms + k_idx;
+				auto new_path = paulis[tmp_pt_idx];
+				new_path.fast_copy_content(p);
+				p.apply_rg(qubit, axis, theta, new_path);
+				k_idx++;
+			}
+		}
+	}
+
 	template <typename PTC>
 	inline static auto expectation_value(PTC const& paulis) -> decltype(paulis[0].expectation_value()) {
 		decltype(paulis[0].expectation_value()) ret = 0;

--- a/include/policies/sequential.hpp
+++ b/include/policies/sequential.hpp
@@ -2,6 +2,7 @@
 #define PP_INCLUDE_POLICY_SEQ_HPP
 
 #include "pauli.hpp"
+#include "pauli_axis.hpp"
 #include "pauli_term_container.hpp"
 #include "container/dirty_set.hpp"
 #include <algorithm>
@@ -155,13 +156,13 @@ struct SequentialPolicy {
 	}
 
 	template <typename PTC, typename T>
-	inline static void apply_rp(PTC& paulis, std::vector<Pauli> const& axis, T theta) {
+	inline static void apply_rp(PTC& paulis, PauliAxis<> const& axis, T theta) {
 		const auto nb_terms = paulis.nb_terms();
 
 		// compute number of required nb_term
 		std::size_t total_to_allocate = 0;
 		for (std::size_t i = 0; i < nb_terms; ++i) {
-			if (!paulis[i].commutes_with(axis)) {
+			if (!paulis[i].commutes_with(axis.raw_bits())) {
 				total_to_allocate++;
 			}
 		}
@@ -172,7 +173,7 @@ struct SequentialPolicy {
 		std::size_t k_idx = 0; // allocated index
 		for (std::size_t i = 0; i < nb_terms; ++i) {
 			auto p = paulis[i];
-			if (!paulis[i].commutes_with(axis)) {
+			if (!paulis[i].commutes_with(axis.raw_bits())) {
 				const auto tmp_pt_idx = nb_terms + k_idx;
 				auto new_path = paulis[tmp_pt_idx];
 				new_path.fast_copy_content(p);

--- a/include/policies/sequential.hpp
+++ b/include/policies/sequential.hpp
@@ -155,7 +155,7 @@ struct SequentialPolicy {
 	}
 
 	template <typename PTC, typename T>
-	inline static void apply_rg(PTC& paulis, std::vector<Pauli> const& axis, unsigned qubit, T theta) {
+	inline static void apply_rg(PTC& paulis, std::vector<Pauli> const& axis, T theta) {
 		const auto nb_terms = paulis.nb_terms();
 
 		// compute number of required nb_term
@@ -176,7 +176,7 @@ struct SequentialPolicy {
 				const auto tmp_pt_idx = nb_terms + k_idx;
 				auto new_path = paulis[tmp_pt_idx];
 				new_path.fast_copy_content(p);
-				p.apply_rg(qubit, axis, theta, new_path);
+				p.apply_rg(axis, theta, new_path);
 				k_idx++;
 			}
 		}

--- a/include/policies/sequential.hpp
+++ b/include/policies/sequential.hpp
@@ -176,8 +176,7 @@ struct SequentialPolicy {
 			if (!paulis[i].commutes_with(axis.raw_bits())) {
 				const auto tmp_pt_idx = nb_terms + k_idx;
 				auto new_path = paulis[tmp_pt_idx];
-				new_path.fast_copy_content(p);
-				p.apply_rp(axis, theta, new_path);
+				p.apply_rp(axis.raw_bits(), theta, new_path);
 				k_idx++;
 			}
 		}

--- a/include/quantum_op.hpp
+++ b/include/quantum_op.hpp
@@ -67,7 +67,7 @@ class QuantumOp {
 	QGate gate; /**< The specific gate or noise channel identifier. */
 	unsigned qubit0;
 	unsigned qubit1;
-	std::vector<Pauli> axis;
+	PauliAxis<> axis;
 	T parameter;
 
     public:
@@ -96,9 +96,9 @@ class QuantumOp {
 	}
 
 	template <typename Real>
-	QuantumOp(QGate qg, std::vector<Pauli> pauli_axis, Real&& v)
+	QuantumOp(QGate qg, std::vector<Pauli> const& pauli_axis, Real&& v)
 		requires(std::is_floating_point_v<std::remove_cvref_t<Real>> || Symbolic<std::remove_cvref_t<Real>>)
-		: gate(qg), axis(std::move(pauli_axis)), parameter(std::move(v)) {}
+		: gate(qg), axis(pauli_axis.begin(), pauli_axis.end()), parameter(std::move(v)) {}
 
 	template <typename ExecutionPolicy = DefaultExecutionPolicy>
 	[[gnu::always_inline]] inline void operator()(ObservableType& obs, ExecutionPolicy&& policy = ExecutionPolicy{}) const {

--- a/include/quantum_op.hpp
+++ b/include/quantum_op.hpp
@@ -67,6 +67,7 @@ class QuantumOp {
 	QGate gate; /**< The specific gate or noise channel identifier. */
 	unsigned qubit0;
 	unsigned qubit1;
+	std::vector<Pauli> axis;
 	T parameter;
 
     public:
@@ -94,11 +95,18 @@ class QuantumOp {
 		}
 	}
 
+	template <typename Real>
+	QuantumOp(QGate qg, std::vector<Pauli> pauli_axis, Real&& v)
+		requires(std::is_floating_point_v<std::remove_cvref_t<Real>> || Symbolic<std::remove_cvref_t<Real>>)
+		: gate(qg), axis(std::move(pauli_axis)), parameter(std::move(v)) {}
+
 	template <typename ExecutionPolicy = DefaultExecutionPolicy>
 	[[gnu::always_inline]] inline void operator()(ObservableType& obs, ExecutionPolicy&& policy = ExecutionPolicy{}) const {
 		switch (gate) {
 		case QGate::Rz:
 			return obs.apply_rz(qubit0, parameter, policy);
+		case QGate::Rp:
+			return obs.apply_rp(axis, parameter, policy);
 		case QGate::Cx:
 			return obs.apply_cx(qubit0, qubit1, policy);
 		case QGate::AmplitudeDamping:
@@ -129,10 +137,11 @@ class QuantumOp {
 	QGate get_gate() const { return gate; }
 
 	[[gnu::always_inline]] inline OperationType operation_type() const {
-		return (gate == QGate::Rz || gate == QGate::AmplitudeDamping) ? OperationType::SplittingGate : OperationType::BasicGate;
+		return (gate == QGate::Rz || gate == QGate::Rp || gate == QGate::AmplitudeDamping) ? OperationType::SplittingGate :
+												     OperationType::BasicGate;
 
-		//static constexpr std::array<OperationType, 2> arr_map{OperationType::BasicGate, OperationType::SplittingGate};
-		//return arr_map[gate == QGate::Rz || gate == QGate::AmplitudeDamping]; // branchless
+		// static constexpr std::array<OperationType, 2> arr_map{OperationType::BasicGate, OperationType::SplittingGate};
+		// return arr_map[gate == QGate::Rz || gate == QGate::AmplitudeDamping]; // branchless
 	}
 };
 

--- a/tests/circuits.cpp
+++ b/tests/circuits.cpp
@@ -397,6 +397,61 @@ TYPED_TEST(CircuitRun, test_circuit1_batch_ev) {
 		EXPECT_NEAR(rev, exp, 1e-4f);
 	}
 }
+TYPED_TEST(CircuitRun, exp_iXXXXt) {
+	Circuit qc{ 4 };
+	Circuit qc_rp{ 4 };
+	Circuit qc_eiht{ 4 };
+	std::vector<Pauli> H{ { p_x, p_x, p_x, p_x } };
+	coeff_t t = 1;
+
+	// transpiled circuit for t = 1
+	qc.add_operation("h", 0);
+	qc.add_operation("h", 1);
+	qc.add_operation("h", 2);
+	qc.add_operation("h", 3);
+	qc.add_operation("cx", 3, 2);
+	qc.add_operation("cx", 2, 1);
+	qc.add_operation("cx", 1, 0);
+	qc.add_operation("rz", 0, 2.0);
+	qc.add_operation("cx", 1, 0);
+	qc.add_operation("h", 0);
+	qc.add_operation("cx", 2, 1);
+	qc.add_operation("h", 1);
+	qc.add_operation("cx", 3, 2);
+	qc.add_operation("h", 2);
+	qc.add_operation("h", 3);
+
+	// using Rp with p = H and theta = 2t
+	qc_rp.add_operation("rp", H, t * 2);
+
+	// using eiht helper
+	qc_eiht.eiht(H, t);
+
+	std::array<std::tuple<std::string_view, coeff_t>, 4> truth_table = { {
+		{ "ZIII", -0.4161468365471419f },
+		{ "IZII", -0.4161468365471419f },
+		{ "IIZI", -0.4161468365471419f },
+		{ "IIIZ", -0.4161468365471419f },
+		//{ "ZZZZ", 0.5f },
+	} };
+	std::vector<Observable<coeff_t>> obses;
+	for (auto const [ob, ev] : truth_table) {
+		obses.push_back(Observable{ ob });
+	}
+
+	auto res_qc = qc.expectation_value(obses, this->policy);
+	auto res_rp = qc_rp.expectation_value(obses, this->policy);
+	auto res_eiht = qc_eiht.expectation_value(obses, this->policy);
+	ASSERT_EQ(res_rp, res_eiht);
+	EXPECT_EQ(res_qc, res_rp);
+	EXPECT_EQ(res_qc, res_eiht);
+
+	for (std::size_t i = 0; i < res_rp.size(); ++i) {
+		auto exp = std::get<1>(truth_table[i]);
+		auto [rev, err] = res_rp[i];
+		EXPECT_NEAR(rev, exp, 1e-4f);
+	}
+}
 
 TYPED_TEST(CircuitRun, bad_observable_throw) {
 	Circuit qc{ 4 };

--- a/tests/circuits.cpp
+++ b/tests/circuits.cpp
@@ -432,7 +432,6 @@ TYPED_TEST(CircuitRun, exp_iXXXXt) {
 		{ "IZII", -0.4161468365471419f },
 		{ "IIZI", -0.4161468365471419f },
 		{ "IIIZ", -0.4161468365471419f },
-		//{ "ZZZZ", 0.5f },
 	} };
 	std::vector<Observable<coeff_t>> obses;
 	for (auto const [ob, ev] : truth_table) {

--- a/tests/observable.cpp
+++ b/tests/observable.cpp
@@ -103,34 +103,6 @@ TYPED_TEST(ObservableTest, apply_pauli) {
 	}
 }
 
-TYPED_TEST(ObservableTest, apply_pauli_runtime) {
-	using enum Pauli_gates;
-	Observable obs{ "IXYZ", "ZXYI" };
-	Observable obs_cpy{ "IXYZ", "ZXYI" };
-	auto pt1 = obs_cpy.copy_term(0);
-	auto pt2 = obs_cpy.copy_term(1);
-
-	// I
-	for (std::size_t i = 0; i < 4; ++i) {
-		obs.apply_pauli(I, i, this->rpolicy);
-		EXPECT_EQ(obs[0], obs_cpy[0]);
-		EXPECT_EQ(obs[1], obs_cpy[1]);
-		EXPECT_EQ(obs.expectation_value(this->rpolicy), obs_cpy.expectation_value(this->rpolicy));
-	}
-
-	// X, Y, Z
-	for (auto g : { I, X, Y, Z }) {
-		for (std::size_t i = 0; i < 4; ++i) {
-			obs.apply_pauli(g, i, this->rpolicy);
-			pt1.apply_pauli(g, i);
-			pt2.apply_pauli(g, i);
-			EXPECT_EQ(obs[0], pt1);
-			EXPECT_EQ(obs[1], pt2);
-			EXPECT_EQ(obs.expectation_value(this->rpolicy), pt1.expectation_value() + pt2.expectation_value());
-		}
-	}
-}
-
 TYPED_TEST(ObservableTest, apply_clifford) {
 	using enum Clifford_Gates_1Q;
 	Observable obs{ "IXYZ", "ZXYI" };
@@ -145,23 +117,6 @@ TYPED_TEST(ObservableTest, apply_clifford) {
 		EXPECT_EQ(obs[0], pt1);
 		EXPECT_EQ(obs[1], pt2);
 		EXPECT_EQ(obs.expectation_value(this->policy), pt1.expectation_value() + pt2.expectation_value());
-	}
-}
-
-TYPED_TEST(ObservableTest, apply_clifford_runtime) {
-	using enum Clifford_Gates_1Q;
-	Observable obs{ "IXYZ", "ZXYI" };
-	Observable obs_cpy{ "IXYZ", "ZXYI" };
-	auto pt1 = obs_cpy.copy_term(0);
-	auto pt2 = obs_cpy.copy_term(1);
-
-	for (std::size_t i = 0; i < 4; ++i) {
-		obs.apply_clifford(H, i, this->rpolicy);
-		pt1.apply_clifford(H, i);
-		pt2.apply_clifford(H, i);
-		EXPECT_EQ(obs[0], pt1);
-		EXPECT_EQ(obs[1], pt2);
-		EXPECT_EQ(obs.expectation_value(this->rpolicy), pt1.expectation_value() + pt2.expectation_value());
 	}
 }
 
@@ -181,26 +136,6 @@ TYPED_TEST(ObservableTest, apply_cx) {
 			EXPECT_EQ(obs[0], pt1);
 			EXPECT_EQ(obs[1], pt2);
 			EXPECT_EQ(obs.expectation_value(this->policy), pt1.expectation_value() + pt2.expectation_value());
-		}
-	}
-}
-
-TYPED_TEST(ObservableTest, apply_cx_runtime) {
-	Observable obs{ "IXYZ", "ZXYI" };
-	Observable obs_cpy{ "IXYZ", "ZXYI" };
-	auto pt1 = obs_cpy.copy_term(0);
-	auto pt2 = obs_cpy.copy_term(1);
-
-	for (std::size_t i = 0; i < 4; ++i) {
-		for (std::size_t j = 0; j < 4; ++j) {
-			if (i == j)
-				continue;
-			obs.apply_cx(i, j, this->rpolicy);
-			pt1.apply_cx(i, j);
-			pt2.apply_cx(i, j);
-			EXPECT_EQ(obs[0], pt1);
-			EXPECT_EQ(obs[1], pt2);
-			EXPECT_EQ(obs.expectation_value(this->rpolicy), pt1.expectation_value() + pt2.expectation_value());
 		}
 	}
 }
@@ -238,7 +173,7 @@ TYPED_TEST(ObservableTest, apply_rz) {
 	}
 }
 
-TYPED_TEST(ObservableTest, apply_rz_runtime) {
+TYPED_TEST(ObservableTest, apply_rg_rz) {
 	Observable obs{ "IXYZZIXYYZXIZXIZI", "ZXYIXYZXZZZYYXXYY" };
 	Observable obs_cpy = obs;
 	PauliTerm<coeff_t> pt1_cpy = obs_cpy.copy_term(0);
@@ -260,14 +195,45 @@ TYPED_TEST(ObservableTest, apply_rz_runtime) {
 		auto expected_ev = std::accumulate(pts.cbegin(), pts.cend(), coeff_t{ 0. },
 						   [](auto acc, auto const& pt) { return acc + pt.expectation_value(); });
 
-		obs.apply_rz(i, theta, this->rpolicy);
+		std::vector<Pauli> axis(obs.nb_qubits(), p_i);
+		axis[i] = p_z;
+		obs.apply_rg(axis, theta, this->policy);
 
 		for (auto const& pt : pts) { // find all terms inside observable
 			auto it = std::find(obs.begin(), obs.end(), pt);
 			ASSERT_NE(it, obs.end());
 			EXPECT_EQ(*it, pt);
 		}
-		EXPECT_EQ(obs.expectation_value(this->rpolicy), expected_ev);
+		EXPECT_EQ(obs.expectation_value(this->policy), expected_ev);
+	}
+}
+
+TYPED_TEST(ObservableTest, apply_rg_rzz) {
+	Observable obs{ "IXYZZIXYYZXIZXIZI", "ZXYIXYZXZZZYYXXYY" };
+	Observable obs_cpy = obs;
+
+	const coeff_t theta = 1.41421356237;
+
+	for (std::size_t i = 0; i < obs.size() - 1; ++i) {
+		auto obs = obs_cpy;
+		auto cpy = obs_cpy;
+
+		cpy.apply_cx(i, i + 1, this->policy);
+		cpy.apply_rz(i + 1, theta, this->policy);
+		cpy.apply_cx(i, i + 1, this->policy);
+
+		std::vector<Pauli> axis(obs.nb_qubits(), p_i);
+		axis[i] = p_z;
+		axis[i + 1] = p_z; // Rz_iz_i+1(theta)
+		obs.apply_rg(axis, theta, this->policy);
+
+		EXPECT_EQ(obs.expectation_value(), cpy.expectation_value());
+		ASSERT_EQ(obs.size(), cpy.size());
+		for (std::size_t j = 0; j < obs.size(); ++j) { // find all terms inside observable
+			auto h = obs[j].phash();
+			auto it = std::find_if(cpy.begin(), cpy.end(), [=](auto const& p) { return p.phash() == h; });
+			ASSERT_NE(it, obs.end());
+		}
 	}
 }
 
@@ -281,26 +247,10 @@ TYPED_TEST(ObservableTest, apply_rz_inverse) {
 	EXPECT_EQ(before_ev, after_ev);
 }
 
-TYPED_TEST(ObservableTest, apply_rz_inverse_runtime) {
-	Observable obs{ "IIXIIIIIIIII" };
-	auto before_ev = obs.expectation_value(this->rpolicy);
-	EXPECT_TRUE(!obs[0].get_pauli(2).commutes_with(p_z));
-	obs.apply_rz(2, 0.125, this->rpolicy);
-	obs.apply_rz(2, -0.125, this->rpolicy);
-	auto after_ev = obs.expectation_value(this->rpolicy);
-	EXPECT_EQ(before_ev, after_ev);
-}
-
 TYPED_TEST(ObservableTest, expectation_value) {
 	EXPECT_EQ(Observable{ "ZI" }.expectation_value(this->policy), 1);
 	EXPECT_EQ(Observable{ "IX" }.expectation_value(this->policy), 0);
 	EXPECT_EQ(Observable{ "YZ" }.expectation_value(this->policy), 0);
-}
-
-TYPED_TEST(ObservableTest, expectation_value_runtime) {
-	EXPECT_EQ(Observable{ "ZI" }.expectation_value(this->rpolicy), 1);
-	EXPECT_EQ(Observable{ "IX" }.expectation_value(this->rpolicy), 0);
-	EXPECT_EQ(Observable{ "YZ" }.expectation_value(this->rpolicy), 0);
 }
 
 TYPED_TEST(ObservableTest, serialize) {
@@ -325,15 +275,6 @@ TYPED_TEST(ObservableTest, merge_simple) {
 	EXPECT_EQ(obs[0], PauliTerm<coeff_t>("IXYZ", 0.25));
 }
 
-TYPED_TEST(ObservableTest, merge_simple_runtime) {
-	Observable obs{ PauliTerm{ "IXYZ", coeff_t{ -0.25 } }, PauliTerm{ "IXYZ", coeff_t{ 0.5 } } };
-	obs.merge(this->rpolicy);
-	EXPECT_EQ(obs.size(), 1);
-	auto nb_elems_internal = std::distance(obs.cbegin(), obs.cend());
-	EXPECT_EQ(nb_elems_internal, 1);
-	EXPECT_EQ(obs[0], PauliTerm<coeff_t>("IXYZ", 0.25));
-}
-
 TYPED_TEST(ObservableTest, merge_long) {
 	Observable obs{ PauliTerm{ "XXXX", coeff_t{ -0.25 } } };
 	for (int i = 0; i < 8; ++i) {
@@ -343,20 +284,6 @@ TYPED_TEST(ObservableTest, merge_long) {
 	EXPECT_GT(std::distance(obs.cbegin(), obs.cend()), 2);
 
 	obs.merge(this->policy);
-
-	auto nb_elems_internal = std::distance(obs.cbegin(), obs.cend());
-	EXPECT_EQ(nb_elems_internal, 2);
-}
-
-TYPED_TEST(ObservableTest, merge_long_runtime) {
-	Observable obs{ PauliTerm{ "XXXX", coeff_t{ -0.25 } } };
-	for (int i = 0; i < 8; ++i) {
-		obs.apply_rz(0, 3.14 / 2, this->policy);
-	}
-
-	EXPECT_GT(std::distance(obs.cbegin(), obs.cend()), 2);
-
-	obs.merge(this->rpolicy);
 
 	auto nb_elems_internal = std::distance(obs.cbegin(), obs.cend());
 	EXPECT_EQ(nb_elems_internal, 2);
@@ -372,22 +299,6 @@ TYPED_TEST(ObservableTest, merge_long_twice) {
 		EXPECT_GT(std::distance(obs.cbegin(), obs.cend()), 2);
 
 		obs.merge(this->policy);
-
-		auto nb_elems_internal = std::distance(obs.cbegin(), obs.cend());
-		EXPECT_EQ(nb_elems_internal, 2);
-	}
-}
-
-TYPED_TEST(ObservableTest, merge_long_twice_runtime) {
-	Observable obs{ PauliTerm{ "XXXX", coeff_t{ -0.25 } } };
-	for (std::size_t i = 0; i < 2; ++i) {
-		for (int i = 0; i < 8; ++i) {
-			obs.apply_rz(0, 3.14 / 2, this->rpolicy);
-		}
-
-		EXPECT_GT(std::distance(obs.cbegin(), obs.cend()), 2);
-
-		obs.merge(this->rpolicy);
 
 		auto nb_elems_internal = std::distance(obs.cbegin(), obs.cend());
 		EXPECT_EQ(nb_elems_internal, 2);
@@ -446,22 +357,6 @@ TYPED_TEST(ObservableTest, depolarizing_noise) {
 	EXPECT_FLOAT_EQ(obs[0].coefficient(), 1.f / (1 << obs[0].size()));
 }
 
-TYPED_TEST(ObservableTest, depolarizing_noise_runtime) {
-	// no effect on I
-	Observable iobs{ "IIII" };
-	for (unsigned i = 0; i < iobs[0].size(); ++i) {
-		iobs.apply_unital_noise(UnitalNoise::Depolarizing, i, 0.5, this->rpolicy);
-	}
-	EXPECT_FLOAT_EQ(iobs[0].coefficient(), 1);
-
-	// affects everything else
-	Observable obs{ "XYZ" };
-	for (unsigned i = 0; i < obs[0].size(); ++i) {
-		obs.apply_unital_noise(UnitalNoise::Depolarizing, i, 0.5, this->rpolicy);
-	}
-	EXPECT_FLOAT_EQ(obs[0].coefficient(), 1.f / (1 << obs[0].size()));
-}
-
 TYPED_TEST(ObservableTest, dephasing_noise) {
 	// no effect on I or Z
 	Observable iobs{ "IZZI" };
@@ -474,22 +369,6 @@ TYPED_TEST(ObservableTest, dephasing_noise) {
 	Observable obs{ "XYYX" };
 	for (unsigned i = 0; i < obs[0].size(); ++i) {
 		obs.apply_unital_noise(UnitalNoise::Dephasing, i, 0.5, this->policy);
-	}
-	EXPECT_FLOAT_EQ(obs[0].coefficient(), 1.f / (1 << obs[0].size()));
-}
-
-TYPED_TEST(ObservableTest, dephasing_noise_runtime) {
-	// no effect on I or Z
-	Observable iobs{ "IZZI" };
-	for (unsigned i = 0; i < iobs[0].size(); ++i) {
-		iobs.apply_unital_noise(UnitalNoise::Dephasing, i, 0.5, this->rpolicy);
-	}
-	EXPECT_FLOAT_EQ(iobs[0].coefficient(), 1);
-
-	// affects everything else
-	Observable obs{ "XYYX" };
-	for (unsigned i = 0; i < obs[0].size(); ++i) {
-		obs.apply_unital_noise(UnitalNoise::Dephasing, i, 0.5, this->rpolicy);
 	}
 	EXPECT_FLOAT_EQ(obs[0].coefficient(), 1.f / (1 << obs[0].size()));
 }
@@ -526,38 +405,6 @@ TYPED_TEST(ObservableTest, amplitude_damping) {
 	EXPECT_FLOAT_EQ((*zpt).coefficient(), std::pow(1 - p, zobs[0].size()));
 }
 
-TYPED_TEST(ObservableTest, amplitude_damping_runtime) {
-	static constexpr coeff_t p = 0.01;
-	// no effect on I
-	Observable iobs{ "IIII" };
-	for (unsigned i = 0; i < iobs[0].size(); ++i) {
-		iobs.apply_amplitude_damping(i, p, this->rpolicy);
-	}
-	EXPECT_EQ(std::distance(iobs.cbegin(), iobs.cend()), 1);
-	EXPECT_FLOAT_EQ(iobs[0].coefficient(), 1);
-
-	// XY no split + sqrt(1-p) coeff
-	Observable xyobs{ "XYXY" };
-	auto xy_ph = xyobs[0].phash();
-	for (unsigned i = 0; i < xyobs[0].size(); ++i) {
-		xyobs.apply_amplitude_damping(i, p, this->rpolicy);
-	}
-	EXPECT_EQ(std::distance(xyobs.cbegin(), xyobs.cend()), 1);
-	EXPECT_FLOAT_EQ(xyobs[0].coefficient(), std::pow(std::sqrt(1 - p), xyobs[0].size()));
-	EXPECT_EQ(xyobs[0].phash(), xy_ph);
-
-	// Z => split + (1-p) coefficient
-	Observable zobs{ "ZZZZ" };
-	auto z_ph = zobs[0].phash();
-	for (unsigned i = 0; i < zobs[0].size(); ++i) {
-		zobs.apply_amplitude_damping(i, p, this->rpolicy);
-	}
-	auto zpt = std::find_if(zobs.cbegin(), zobs.cend(), [=](auto const& pt) { return pt.phash() == z_ph; });
-	ASSERT_TRUE(zpt != zobs.cend());
-	EXPECT_EQ(std::distance(zobs.cbegin(), zobs.cend()), std::pow(2, zobs[0].size()));
-	EXPECT_FLOAT_EQ((*zpt).coefficient(), std::pow(1 - p, zobs[0].size()));
-}
-
 TYPED_TEST(ObservableTest, bad_init_throw) {
 	EXPECT_THROW({ Observable obs(""); }, std::invalid_argument);
 	EXPECT_THROW({ Observable obs{ std::initializer_list<std::string_view>{} }; }, std::invalid_argument);
@@ -584,16 +431,4 @@ TYPED_TEST(ObservableTest, bad_gate_target_throw) {
 	EXPECT_THROW({ obs.apply_pauli(Pauli_gates::X, 2, this->policy); }, std::invalid_argument);
 	EXPECT_THROW({ obs.apply_cx(2, 0, this->policy); }, std::invalid_argument);
 	EXPECT_THROW({ obs.apply_cx(1, 1, this->policy); }, std::invalid_argument);
-}
-
-TYPED_TEST(ObservableTest, bad_gate_target_throw_runtime) {
-	Observable obs{ "II" };
-	EXPECT_THROW({ obs.apply_unital_noise(UnitalNoise::Dephasing, 2, 0.1f, this->rpolicy); }, std::invalid_argument);
-	EXPECT_THROW({ obs.apply_amplitude_damping(2, 0.1f, this->rpolicy); }, std::invalid_argument);
-	EXPECT_THROW({ obs.apply_rz(2, 0.1f, this->rpolicy); }, std::invalid_argument);
-	EXPECT_THROW({ obs.apply_cx(0, 2, this->rpolicy); }, std::invalid_argument);
-	EXPECT_THROW({ obs.apply_clifford(Clifford_Gates_1Q::H, 2, this->rpolicy); }, std::invalid_argument);
-	EXPECT_THROW({ obs.apply_pauli(Pauli_gates::X, 2, this->rpolicy); }, std::invalid_argument);
-	EXPECT_THROW({ obs.apply_cx(2, 0, this->rpolicy); }, std::invalid_argument);
-	EXPECT_THROW({ obs.apply_cx(1, 1, this->rpolicy); }, std::invalid_argument);
 }

--- a/tests/observable.cpp
+++ b/tests/observable.cpp
@@ -275,45 +275,6 @@ TYPED_TEST(ObservableTest, apply_rp_exp_ixzyx) {
 	}
 }
 
-TYPED_TEST(ObservableTest, apply_exp_ixzyx) {
-	Observable obs{ "ZIII", "IZII", "IIZI", "IIIZ" };
-	Observable cpy = obs;
-	coeff_t t = 1; // NOTE: Rp(theta) = exp(-iP * (theta/2))
-
-	// transpiled circuit for exp(-iHt) with t=1 and H=XZYX (inversed)
-	cpy.apply_clifford(Clifford_Gates_1Q::H, 3, this->policy);
-	cpy.apply_cx(3, 2, this->policy);
-	cpy.apply_rz(1, 1.5707963267948966, this->policy);
-	cpy.apply_clifford(Clifford_Gates_1Q::H, 1, this->policy);
-	cpy.apply_rz(1, 1.5707963267948966, this->policy);
-	cpy.apply_cx(2, 1, this->policy);
-	cpy.apply_clifford(Clifford_Gates_1Q::H, 0, this->policy);
-	cpy.apply_cx(1, 0, this->policy);
-	cpy.apply_rz(0, 2.0, this->policy);
-	cpy.apply_cx(1, 0, this->policy);
-	cpy.apply_cx(2, 1, this->policy);
-	cpy.apply_cx(3, 2, this->policy);
-	cpy.apply_clifford(Clifford_Gates_1Q::H, 3, this->policy);
-	cpy.apply_rz(1, -1.5707963267948966, this->policy);
-	cpy.apply_clifford(Clifford_Gates_1Q::H, 1, this->policy);
-	cpy.apply_rz(1, -1.5707963267948966, this->policy);
-	cpy.apply_clifford(Clifford_Gates_1Q::H, 0, this->policy);
-	cpy.merge(this->policy);
-
-	std::vector<Pauli> axis{ { p_x, p_z, p_y, p_x } }; // XZYX
-	obs.apply_exp_iht(axis, t, this->policy);
-	obs.merge(this->policy);
-
-	EXPECT_NEAR(obs.expectation_value(), cpy.expectation_value(), 1e-6f);
-	ASSERT_LE(obs.size(), cpy.size());
-	for (std::size_t j = 0; j < obs.size(); ++j) { // find all terms inside observable
-		auto h = obs[j].phash();
-		auto it = std::find_if(cpy.begin(), cpy.end(), [=](auto const& p) { return p.phash() == h; });
-		ASSERT_NE(it, obs.end());
-	}
-}
-
-
 TYPED_TEST(ObservableTest, apply_rz_inverse) {
 	Observable obs{ "IIXIIIIIIIII" };
 	auto before_ev = obs.expectation_value(this->policy);

--- a/tests/observable.cpp
+++ b/tests/observable.cpp
@@ -237,6 +237,44 @@ TYPED_TEST(ObservableTest, apply_rg_rzz) {
 	}
 }
 
+TYPED_TEST(ObservableTest, apply_rg_exp_ixzyx) {
+	Observable obs{ "ZIII", "IZII", "IIZI", "IIIZ" };
+	Observable cpy = obs;
+	coeff_t theta = 2;
+
+	// transpiled circuit for exp(-iHt) with t=1 and H=XZYX (inversed)
+	cpy.apply_clifford(Clifford_Gates_1Q::H, 3, this->policy);
+	cpy.apply_cx(3, 2, this->policy);
+	cpy.apply_rz(1, 1.5707963267948966, this->policy);
+	cpy.apply_clifford(Clifford_Gates_1Q::H, 1, this->policy);
+	cpy.apply_rz(1, 1.5707963267948966, this->policy);
+	cpy.apply_cx(2, 1, this->policy);
+	cpy.apply_clifford(Clifford_Gates_1Q::H, 0, this->policy);
+	cpy.apply_cx(1, 0, this->policy);
+	cpy.apply_rz(0, 2.0, this->policy);
+	cpy.apply_cx(1, 0, this->policy);
+	cpy.apply_cx(2, 1, this->policy);
+	cpy.apply_cx(3, 2, this->policy);
+	cpy.apply_clifford(Clifford_Gates_1Q::H, 3, this->policy);
+	cpy.apply_rz(1, -1.5707963267948966, this->policy);
+	cpy.apply_clifford(Clifford_Gates_1Q::H, 1, this->policy);
+	cpy.apply_rz(1, -1.5707963267948966, this->policy);
+	cpy.apply_clifford(Clifford_Gates_1Q::H, 0, this->policy);
+	cpy.merge(this->policy);
+
+	std::vector<Pauli> axis{ { p_x, p_z, p_y, p_x } }; // XZYX
+	obs.apply_rg(axis, theta, this->policy);
+	obs.merge(this->policy);
+
+	EXPECT_NEAR(obs.expectation_value(), cpy.expectation_value(), 1e-6f);
+	ASSERT_LE(obs.size(), cpy.size());
+	for (std::size_t j = 0; j < obs.size(); ++j) { // find all terms inside observable
+		auto h = obs[j].phash();
+		auto it = std::find_if(cpy.begin(), cpy.end(), [=](auto const& p) { return p.phash() == h; });
+		ASSERT_NE(it, obs.end());
+	}
+}
+
 TYPED_TEST(ObservableTest, apply_rz_inverse) {
 	Observable obs{ "IIXIIIIIIIII" };
 	auto before_ev = obs.expectation_value(this->policy);

--- a/tests/observable.cpp
+++ b/tests/observable.cpp
@@ -173,7 +173,7 @@ TYPED_TEST(ObservableTest, apply_rz) {
 	}
 }
 
-TYPED_TEST(ObservableTest, apply_rg_rz) {
+TYPED_TEST(ObservableTest, apply_rp_rz) {
 	Observable obs{ "IXYZZIXYYZXIZXIZI", "ZXYIXYZXZZZYYXXYY" };
 	Observable obs_cpy = obs;
 	PauliTerm<coeff_t> pt1_cpy = obs_cpy.copy_term(0);
@@ -197,7 +197,7 @@ TYPED_TEST(ObservableTest, apply_rg_rz) {
 
 		std::vector<Pauli> axis(obs.nb_qubits(), p_i);
 		axis[i] = p_z;
-		obs.apply_rg(axis, theta, this->policy);
+		obs.apply_rp(axis, theta, this->policy);
 
 		for (auto const& pt : pts) { // find all terms inside observable
 			auto it = std::find(obs.begin(), obs.end(), pt);
@@ -208,7 +208,7 @@ TYPED_TEST(ObservableTest, apply_rg_rz) {
 	}
 }
 
-TYPED_TEST(ObservableTest, apply_rg_rzz) {
+TYPED_TEST(ObservableTest, apply_rp_rzz) {
 	Observable obs{ "IXYZZIXYYZXIZXIZI", "ZXYIXYZXZZZYYXXYY" };
 	Observable obs_cpy = obs;
 
@@ -225,7 +225,7 @@ TYPED_TEST(ObservableTest, apply_rg_rzz) {
 		std::vector<Pauli> axis(obs.nb_qubits(), p_i);
 		axis[i] = p_z;
 		axis[i + 1] = p_z; // Rz_iz_i+1(theta)
-		obs.apply_rg(axis, theta, this->policy);
+		obs.apply_rp(axis, theta, this->policy);
 
 		EXPECT_EQ(obs.expectation_value(), cpy.expectation_value());
 		ASSERT_EQ(obs.size(), cpy.size());
@@ -237,7 +237,7 @@ TYPED_TEST(ObservableTest, apply_rg_rzz) {
 	}
 }
 
-TYPED_TEST(ObservableTest, apply_rg_exp_ixzyx) {
+TYPED_TEST(ObservableTest, apply_rp_exp_ixzyx) {
 	Observable obs{ "ZIII", "IZII", "IIZI", "IIIZ" };
 	Observable cpy = obs;
 	coeff_t theta = 2; // NOTE: Rp(theta) = exp(-iP * (theta/2))
@@ -263,7 +263,7 @@ TYPED_TEST(ObservableTest, apply_rg_exp_ixzyx) {
 	cpy.merge(this->policy);
 
 	std::vector<Pauli> axis{ { p_x, p_z, p_y, p_x } }; // XZYX
-	obs.apply_rg(axis, theta, this->policy);
+	obs.apply_rp(axis, theta, this->policy);
 	obs.merge(this->policy);
 
 	EXPECT_NEAR(obs.expectation_value(), cpy.expectation_value(), 1e-6f);

--- a/tests/observable.cpp
+++ b/tests/observable.cpp
@@ -84,21 +84,21 @@ TYPED_TEST(ObservableTest, apply_pauli) {
 
 	// I
 	for (std::size_t i = 0; i < 4; ++i) {
-		obs.apply_pauli(I, i, this->policy);
+		obs.apply_pauli(I, i, this->rpolicy);
 		EXPECT_EQ(obs[0], obs_cpy[0]);
 		EXPECT_EQ(obs[1], obs_cpy[1]);
-		EXPECT_EQ(obs.expectation_value(this->policy), obs_cpy.expectation_value(this->policy));
+		EXPECT_EQ(obs.expectation_value(this->rpolicy), obs_cpy.expectation_value(this->rpolicy));
 	}
 
 	// X, Y, Z
 	for (auto g : { I, X, Y, Z }) {
 		for (std::size_t i = 0; i < 4; ++i) {
-			obs.apply_pauli(g, i, this->policy);
+			obs.apply_pauli(g, i, this->rpolicy);
 			pt1.apply_pauli(g, i);
 			pt2.apply_pauli(g, i);
 			EXPECT_EQ(obs[0], pt1);
 			EXPECT_EQ(obs[1], pt2);
-			EXPECT_EQ(obs.expectation_value(this->policy), pt1.expectation_value() + pt2.expectation_value());
+			EXPECT_EQ(obs.expectation_value(this->rpolicy), pt1.expectation_value() + pt2.expectation_value());
 		}
 	}
 }
@@ -111,12 +111,12 @@ TYPED_TEST(ObservableTest, apply_clifford) {
 	auto pt2 = obs_cpy.copy_term(1);
 
 	for (std::size_t i = 0; i < 4; ++i) {
-		obs.apply_clifford(H, i, this->policy);
+		obs.apply_clifford(H, i, this->rpolicy);
 		pt1.apply_clifford(H, i);
 		pt2.apply_clifford(H, i);
 		EXPECT_EQ(obs[0], pt1);
 		EXPECT_EQ(obs[1], pt2);
-		EXPECT_EQ(obs.expectation_value(this->policy), pt1.expectation_value() + pt2.expectation_value());
+		EXPECT_EQ(obs.expectation_value(this->rpolicy), pt1.expectation_value() + pt2.expectation_value());
 	}
 }
 
@@ -130,12 +130,12 @@ TYPED_TEST(ObservableTest, apply_cx) {
 		for (std::size_t j = 0; j < 4; ++j) {
 			if (i == j)
 				continue;
-			obs.apply_cx(i, j, this->policy);
+			obs.apply_cx(i, j, this->rpolicy);
 			pt1.apply_cx(i, j);
 			pt2.apply_cx(i, j);
 			EXPECT_EQ(obs[0], pt1);
 			EXPECT_EQ(obs[1], pt2);
-			EXPECT_EQ(obs.expectation_value(this->policy), pt1.expectation_value() + pt2.expectation_value());
+			EXPECT_EQ(obs.expectation_value(this->rpolicy), pt1.expectation_value() + pt2.expectation_value());
 		}
 	}
 }
@@ -162,14 +162,14 @@ TYPED_TEST(ObservableTest, apply_rz) {
 		auto expected_ev = std::accumulate(pts.cbegin(), pts.cend(), coeff_t{ 0. },
 						   [](auto acc, auto const& pt) { return acc + pt.expectation_value(); });
 
-		obs.apply_rz(i, theta, this->policy);
+		obs.apply_rz(i, theta, this->rpolicy);
 
 		for (auto const& pt : pts) { // find all terms inside observable
 			auto it = std::find(obs.begin(), obs.end(), pt);
 			ASSERT_NE(it, obs.end());
 			EXPECT_EQ(*it, pt);
 		}
-		EXPECT_EQ(obs.expectation_value(this->policy), expected_ev);
+		EXPECT_EQ(obs.expectation_value(this->rpolicy), expected_ev);
 	}
 }
 
@@ -197,14 +197,14 @@ TYPED_TEST(ObservableTest, apply_rp_rz) {
 
 		std::vector<Pauli> axis(obs.nb_qubits(), p_i);
 		axis[i] = p_z;
-		obs.apply_rp(axis, theta, this->policy);
+		obs.apply_rp(axis, theta, this->rpolicy);
 
 		for (auto const& pt : pts) { // find all terms inside observable
 			auto it = std::find(obs.begin(), obs.end(), pt);
 			ASSERT_NE(it, obs.end());
 			EXPECT_EQ(*it, pt);
 		}
-		EXPECT_EQ(obs.expectation_value(this->policy), expected_ev);
+		EXPECT_EQ(obs.expectation_value(this->rpolicy), expected_ev);
 	}
 }
 
@@ -218,14 +218,14 @@ TYPED_TEST(ObservableTest, apply_rp_rzz) {
 		auto obs = obs_cpy;
 		auto cpy = obs_cpy;
 
-		cpy.apply_cx(i, i + 1, this->policy);
-		cpy.apply_rz(i + 1, theta, this->policy);
-		cpy.apply_cx(i, i + 1, this->policy);
+		cpy.apply_cx(i, i + 1, this->rpolicy);
+		cpy.apply_rz(i + 1, theta, this->rpolicy);
+		cpy.apply_cx(i, i + 1, this->rpolicy);
 
 		std::vector<Pauli> axis(obs.nb_qubits(), p_i);
 		axis[i] = p_z;
 		axis[i + 1] = p_z; // Rz_iz_i+1(theta)
-		obs.apply_rp(axis, theta, this->policy);
+		obs.apply_rp(axis, theta, this->rpolicy);
 
 		EXPECT_EQ(obs.expectation_value(), cpy.expectation_value());
 		ASSERT_EQ(obs.size(), cpy.size());
@@ -243,28 +243,28 @@ TYPED_TEST(ObservableTest, apply_rp_exp_ixzyx) {
 	coeff_t theta = 2; // NOTE: Rp(theta) = exp(-iP * (theta/2))
 
 	// transpiled circuit for exp(-iHt) with t=1 and H=XZYX (inversed)
-	cpy.apply_clifford(Clifford_Gates_1Q::H, 3, this->policy);
-	cpy.apply_cx(3, 2, this->policy);
-	cpy.apply_rz(1, 1.5707963267948966, this->policy);
-	cpy.apply_clifford(Clifford_Gates_1Q::H, 1, this->policy);
-	cpy.apply_rz(1, 1.5707963267948966, this->policy);
-	cpy.apply_cx(2, 1, this->policy);
-	cpy.apply_clifford(Clifford_Gates_1Q::H, 0, this->policy);
-	cpy.apply_cx(1, 0, this->policy);
-	cpy.apply_rz(0, 2.0, this->policy);
-	cpy.apply_cx(1, 0, this->policy);
-	cpy.apply_cx(2, 1, this->policy);
-	cpy.apply_cx(3, 2, this->policy);
-	cpy.apply_clifford(Clifford_Gates_1Q::H, 3, this->policy);
-	cpy.apply_rz(1, -1.5707963267948966, this->policy);
-	cpy.apply_clifford(Clifford_Gates_1Q::H, 1, this->policy);
-	cpy.apply_rz(1, -1.5707963267948966, this->policy);
-	cpy.apply_clifford(Clifford_Gates_1Q::H, 0, this->policy);
-	cpy.merge(this->policy);
+	cpy.apply_clifford(Clifford_Gates_1Q::H, 3, this->rpolicy);
+	cpy.apply_cx(3, 2, this->rpolicy);
+	cpy.apply_rz(1, 1.5707963267948966, this->rpolicy);
+	cpy.apply_clifford(Clifford_Gates_1Q::H, 1, this->rpolicy);
+	cpy.apply_rz(1, 1.5707963267948966, this->rpolicy);
+	cpy.apply_cx(2, 1, this->rpolicy);
+	cpy.apply_clifford(Clifford_Gates_1Q::H, 0, this->rpolicy);
+	cpy.apply_cx(1, 0, this->rpolicy);
+	cpy.apply_rz(0, 2.0, this->rpolicy);
+	cpy.apply_cx(1, 0, this->rpolicy);
+	cpy.apply_cx(2, 1, this->rpolicy);
+	cpy.apply_cx(3, 2, this->rpolicy);
+	cpy.apply_clifford(Clifford_Gates_1Q::H, 3, this->rpolicy);
+	cpy.apply_rz(1, -1.5707963267948966, this->rpolicy);
+	cpy.apply_clifford(Clifford_Gates_1Q::H, 1, this->rpolicy);
+	cpy.apply_rz(1, -1.5707963267948966, this->rpolicy);
+	cpy.apply_clifford(Clifford_Gates_1Q::H, 0, this->rpolicy);
+	cpy.merge(this->rpolicy);
 
 	std::vector<Pauli> axis{ { p_x, p_z, p_y, p_x } }; // XZYX
-	obs.apply_rp(axis, theta, this->policy);
-	obs.merge(this->policy);
+	obs.apply_rp(axis, theta, this->rpolicy);
+	obs.merge(this->rpolicy);
 
 	EXPECT_NEAR(obs.expectation_value(), cpy.expectation_value(), 1e-6f);
 	ASSERT_LE(obs.size(), cpy.size());
@@ -277,18 +277,18 @@ TYPED_TEST(ObservableTest, apply_rp_exp_ixzyx) {
 
 TYPED_TEST(ObservableTest, apply_rz_inverse) {
 	Observable obs{ "IIXIIIIIIIII" };
-	auto before_ev = obs.expectation_value(this->policy);
+	auto before_ev = obs.expectation_value(this->rpolicy);
 	EXPECT_TRUE(!obs[0].get_pauli(2).commutes_with(p_z));
-	obs.apply_rz(2, 0.125, this->policy);
-	obs.apply_rz(2, -0.125, this->policy);
-	auto after_ev = obs.expectation_value(this->policy);
+	obs.apply_rz(2, 0.125, this->rpolicy);
+	obs.apply_rz(2, -0.125, this->rpolicy);
+	auto after_ev = obs.expectation_value(this->rpolicy);
 	EXPECT_EQ(before_ev, after_ev);
 }
 
 TYPED_TEST(ObservableTest, expectation_value) {
-	EXPECT_EQ(Observable{ "ZI" }.expectation_value(this->policy), 1);
-	EXPECT_EQ(Observable{ "IX" }.expectation_value(this->policy), 0);
-	EXPECT_EQ(Observable{ "YZ" }.expectation_value(this->policy), 0);
+	EXPECT_EQ(Observable{ "ZI" }.expectation_value(this->rpolicy), 1);
+	EXPECT_EQ(Observable{ "IX" }.expectation_value(this->rpolicy), 0);
+	EXPECT_EQ(Observable{ "YZ" }.expectation_value(this->rpolicy), 0);
 }
 
 TYPED_TEST(ObservableTest, serialize) {
@@ -306,7 +306,7 @@ TYPED_TEST(ObservableTest, serialize) {
 
 TYPED_TEST(ObservableTest, merge_simple) {
 	Observable obs{ PauliTerm{ "IXYZ", coeff_t{ -0.25 } }, PauliTerm{ "IXYZ", coeff_t{ 0.5 } } };
-	obs.merge(this->policy);
+	obs.merge(this->rpolicy);
 	EXPECT_EQ(obs.size(), 1);
 	auto nb_elems_internal = std::distance(obs.cbegin(), obs.cend());
 	EXPECT_EQ(nb_elems_internal, 1);
@@ -316,12 +316,12 @@ TYPED_TEST(ObservableTest, merge_simple) {
 TYPED_TEST(ObservableTest, merge_long) {
 	Observable obs{ PauliTerm{ "XXXX", coeff_t{ -0.25 } } };
 	for (int i = 0; i < 8; ++i) {
-		obs.apply_rz(0, 3.14 / 2, this->policy);
+		obs.apply_rz(0, 3.14 / 2, this->rpolicy);
 	}
 
 	EXPECT_GT(std::distance(obs.cbegin(), obs.cend()), 2);
 
-	obs.merge(this->policy);
+	obs.merge(this->rpolicy);
 
 	auto nb_elems_internal = std::distance(obs.cbegin(), obs.cend());
 	EXPECT_EQ(nb_elems_internal, 2);
@@ -331,12 +331,12 @@ TYPED_TEST(ObservableTest, merge_long_twice) {
 	Observable obs{ PauliTerm{ "XXXX", coeff_t{ -0.25 } } };
 	for (std::size_t i = 0; i < 2; ++i) {
 		for (int i = 0; i < 8; ++i) {
-			obs.apply_rz(0, 3.14 / 2, this->policy);
+			obs.apply_rz(0, 3.14 / 2, this->rpolicy);
 		}
 
 		EXPECT_GT(std::distance(obs.cbegin(), obs.cend()), 2);
 
-		obs.merge(this->policy);
+		obs.merge(this->rpolicy);
 
 		auto nb_elems_internal = std::distance(obs.cbegin(), obs.cend());
 		EXPECT_EQ(nb_elems_internal, 2);
@@ -383,14 +383,14 @@ TYPED_TEST(ObservableTest, depolarizing_noise) {
 	// no effect on I
 	Observable iobs{ "IIII" };
 	for (unsigned i = 0; i < iobs[0].size(); ++i) {
-		iobs.apply_unital_noise(UnitalNoise::Depolarizing, i, 0.5, this->policy);
+		iobs.apply_unital_noise(UnitalNoise::Depolarizing, i, 0.5, this->rpolicy);
 	}
 	EXPECT_FLOAT_EQ(iobs[0].coefficient(), 1);
 
 	// affects everything else
 	Observable obs{ "XYZ" };
 	for (unsigned i = 0; i < obs[0].size(); ++i) {
-		obs.apply_unital_noise(UnitalNoise::Depolarizing, i, 0.5, this->policy);
+		obs.apply_unital_noise(UnitalNoise::Depolarizing, i, 0.5, this->rpolicy);
 	}
 	EXPECT_FLOAT_EQ(obs[0].coefficient(), 1.f / (1 << obs[0].size()));
 }
@@ -399,14 +399,14 @@ TYPED_TEST(ObservableTest, dephasing_noise) {
 	// no effect on I or Z
 	Observable iobs{ "IZZI" };
 	for (unsigned i = 0; i < iobs[0].size(); ++i) {
-		iobs.apply_unital_noise(UnitalNoise::Dephasing, i, 0.5, this->policy);
+		iobs.apply_unital_noise(UnitalNoise::Dephasing, i, 0.5, this->rpolicy);
 	}
 	EXPECT_FLOAT_EQ(iobs[0].coefficient(), 1);
 
 	// affects everything else
 	Observable obs{ "XYYX" };
 	for (unsigned i = 0; i < obs[0].size(); ++i) {
-		obs.apply_unital_noise(UnitalNoise::Dephasing, i, 0.5, this->policy);
+		obs.apply_unital_noise(UnitalNoise::Dephasing, i, 0.5, this->rpolicy);
 	}
 	EXPECT_FLOAT_EQ(obs[0].coefficient(), 1.f / (1 << obs[0].size()));
 }
@@ -416,7 +416,7 @@ TYPED_TEST(ObservableTest, amplitude_damping) {
 	// no effect on I
 	Observable iobs{ "IIII" };
 	for (unsigned i = 0; i < iobs[0].size(); ++i) {
-		iobs.apply_amplitude_damping(i, p, this->policy);
+		iobs.apply_amplitude_damping(i, p, this->rpolicy);
 	}
 	EXPECT_EQ(std::distance(iobs.cbegin(), iobs.cend()), 1);
 	EXPECT_FLOAT_EQ(iobs[0].coefficient(), 1);
@@ -425,7 +425,7 @@ TYPED_TEST(ObservableTest, amplitude_damping) {
 	Observable xyobs{ "XYXY" };
 	auto xy_ph = xyobs[0].phash();
 	for (unsigned i = 0; i < xyobs[0].size(); ++i) {
-		xyobs.apply_amplitude_damping(i, p, this->policy);
+		xyobs.apply_amplitude_damping(i, p, this->rpolicy);
 	}
 	EXPECT_EQ(std::distance(xyobs.cbegin(), xyobs.cend()), 1);
 	EXPECT_FLOAT_EQ(xyobs[0].coefficient(), std::pow(std::sqrt(1 - p), xyobs[0].size()));
@@ -435,7 +435,7 @@ TYPED_TEST(ObservableTest, amplitude_damping) {
 	Observable zobs{ "ZZZZ" };
 	auto z_ph = zobs[0].phash();
 	for (unsigned i = 0; i < zobs[0].size(); ++i) {
-		zobs.apply_amplitude_damping(i, p, this->policy);
+		zobs.apply_amplitude_damping(i, p, this->rpolicy);
 	}
 	auto zpt = std::find_if(zobs.cbegin(), zobs.cend(), [=](auto const& pt) { return pt.phash() == z_ph; });
 	ASSERT_TRUE(zpt != zobs.cend());
@@ -461,12 +461,12 @@ TYPED_TEST(ObservableTest, bad_init_throw) {
 
 TYPED_TEST(ObservableTest, bad_gate_target_throw) {
 	Observable obs{ "II" };
-	EXPECT_THROW({ obs.apply_unital_noise(UnitalNoise::Dephasing, 2, 0.1f, this->policy); }, std::invalid_argument);
-	EXPECT_THROW({ obs.apply_amplitude_damping(2, 0.1f, this->policy); }, std::invalid_argument);
-	EXPECT_THROW({ obs.apply_rz(2, 0.1f, this->policy); }, std::invalid_argument);
-	EXPECT_THROW({ obs.apply_cx(0, 2, this->policy); }, std::invalid_argument);
-	EXPECT_THROW({ obs.apply_clifford(Clifford_Gates_1Q::H, 2, this->policy); }, std::invalid_argument);
-	EXPECT_THROW({ obs.apply_pauli(Pauli_gates::X, 2, this->policy); }, std::invalid_argument);
-	EXPECT_THROW({ obs.apply_cx(2, 0, this->policy); }, std::invalid_argument);
-	EXPECT_THROW({ obs.apply_cx(1, 1, this->policy); }, std::invalid_argument);
+	EXPECT_THROW({ obs.apply_unital_noise(UnitalNoise::Dephasing, 2, 0.1f, this->rpolicy); }, std::invalid_argument);
+	EXPECT_THROW({ obs.apply_amplitude_damping(2, 0.1f, this->rpolicy); }, std::invalid_argument);
+	EXPECT_THROW({ obs.apply_rz(2, 0.1f, this->rpolicy); }, std::invalid_argument);
+	EXPECT_THROW({ obs.apply_cx(0, 2, this->rpolicy); }, std::invalid_argument);
+	EXPECT_THROW({ obs.apply_clifford(Clifford_Gates_1Q::H, 2, this->rpolicy); }, std::invalid_argument);
+	EXPECT_THROW({ obs.apply_pauli(Pauli_gates::X, 2, this->rpolicy); }, std::invalid_argument);
+	EXPECT_THROW({ obs.apply_cx(2, 0, this->rpolicy); }, std::invalid_argument);
+	EXPECT_THROW({ obs.apply_cx(1, 1, this->rpolicy); }, std::invalid_argument);
 }

--- a/tests/observable.cpp
+++ b/tests/observable.cpp
@@ -240,7 +240,7 @@ TYPED_TEST(ObservableTest, apply_rg_rzz) {
 TYPED_TEST(ObservableTest, apply_rg_exp_ixzyx) {
 	Observable obs{ "ZIII", "IZII", "IIZI", "IIIZ" };
 	Observable cpy = obs;
-	coeff_t theta = 2;
+	coeff_t theta = 2; // NOTE: Rp(theta) = exp(-iP * (theta/2))
 
 	// transpiled circuit for exp(-iHt) with t=1 and H=XZYX (inversed)
 	cpy.apply_clifford(Clifford_Gates_1Q::H, 3, this->policy);
@@ -274,6 +274,45 @@ TYPED_TEST(ObservableTest, apply_rg_exp_ixzyx) {
 		ASSERT_NE(it, obs.end());
 	}
 }
+
+TYPED_TEST(ObservableTest, apply_exp_ixzyx) {
+	Observable obs{ "ZIII", "IZII", "IIZI", "IIIZ" };
+	Observable cpy = obs;
+	coeff_t t = 1; // NOTE: Rp(theta) = exp(-iP * (theta/2))
+
+	// transpiled circuit for exp(-iHt) with t=1 and H=XZYX (inversed)
+	cpy.apply_clifford(Clifford_Gates_1Q::H, 3, this->policy);
+	cpy.apply_cx(3, 2, this->policy);
+	cpy.apply_rz(1, 1.5707963267948966, this->policy);
+	cpy.apply_clifford(Clifford_Gates_1Q::H, 1, this->policy);
+	cpy.apply_rz(1, 1.5707963267948966, this->policy);
+	cpy.apply_cx(2, 1, this->policy);
+	cpy.apply_clifford(Clifford_Gates_1Q::H, 0, this->policy);
+	cpy.apply_cx(1, 0, this->policy);
+	cpy.apply_rz(0, 2.0, this->policy);
+	cpy.apply_cx(1, 0, this->policy);
+	cpy.apply_cx(2, 1, this->policy);
+	cpy.apply_cx(3, 2, this->policy);
+	cpy.apply_clifford(Clifford_Gates_1Q::H, 3, this->policy);
+	cpy.apply_rz(1, -1.5707963267948966, this->policy);
+	cpy.apply_clifford(Clifford_Gates_1Q::H, 1, this->policy);
+	cpy.apply_rz(1, -1.5707963267948966, this->policy);
+	cpy.apply_clifford(Clifford_Gates_1Q::H, 0, this->policy);
+	cpy.merge(this->policy);
+
+	std::vector<Pauli> axis{ { p_x, p_z, p_y, p_x } }; // XZYX
+	obs.apply_exp_iht(axis, t, this->policy);
+	obs.merge(this->policy);
+
+	EXPECT_NEAR(obs.expectation_value(), cpy.expectation_value(), 1e-6f);
+	ASSERT_LE(obs.size(), cpy.size());
+	for (std::size_t j = 0; j < obs.size(); ++j) { // find all terms inside observable
+		auto h = obs[j].phash();
+		auto it = std::find_if(cpy.begin(), cpy.end(), [=](auto const& p) { return p.phash() == h; });
+		ASSERT_NE(it, obs.end());
+	}
+}
+
 
 TYPED_TEST(ObservableTest, apply_rz_inverse) {
 	Observable obs{ "IIXIIIIIIIII" };

--- a/tests/pauli.cpp
+++ b/tests/pauli.cpp
@@ -115,9 +115,7 @@ TEST(Pauli, apply_hadamard) {
 	// https://arxiv.org/pdf/2505.21606
 
 	using enum Pauli_enum;
-	std::array<std::tuple<Pauli, coeff_t, Pauli>, 4> truth_table = {
-		{ { I, 1, I }, { X, 1, Z }, { Y, -1, Y }, { Z, 1, X } }
-	};
+	std::array<std::tuple<Pauli, coeff_t, Pauli>, 4> truth_table = { { { I, 1, I }, { X, 1, Z }, { Y, -1, Y }, { Z, 1, X } } };
 	for (auto [in_pauli, out_coeff, out_pauli] : truth_table) {
 		auto c = in_pauli.apply_clifford(Clifford_Gates_1Q::H);
 		EXPECT_EQ(in_pauli, out_pauli);
@@ -157,9 +155,7 @@ TEST(Pauli, apply_cx) {
 
 TEST(Pauli, serialize) {
 	using enum Pauli_enum;
-	std::array<std::tuple<std::string_view, Pauli>, 4> truth_table{
-		{ { "I", I }, { "X", X }, { "Y", Y }, { "Z", Z } }
-	};
+	std::array<std::tuple<std::string_view, Pauli>, 4> truth_table{ { { "I", I }, { "X", X }, { "Y", Y }, { "Z", Z } } };
 
 	for (auto const [expected_str, p] : truth_table) {
 		std::stringstream ss;
@@ -190,4 +186,43 @@ TEST(Pauli, dephasing_noise) {
 	EXPECT_FLOAT_EQ(p_x.apply_unital_noise(Dephasing, 0.01), 0.99);
 	EXPECT_FLOAT_EQ(p_y.apply_unital_noise(Dephasing, 0.01), 0.99);
 	EXPECT_EQ(p_z.apply_unital_noise(Dephasing, 0.01), 1.);
+}
+
+TEST(Pauli, MultiplyRight) {
+	using enum Pauli_enum;
+
+	std::array<std::tuple<Pauli, Pauli, Pauli, int>, 16> truth_table{ {
+		// Products with Identity
+		{ I, I, I, 0 },
+		{ I, X, X, 0 },
+		{ I, Y, Y, 0 },
+		{ I, Z, Z, 0 },
+		{ X, I, X, 0 },
+		{ Y, I, Y, 0 },
+		{ Z, I, Z, 0 },
+
+		// Products of a Pauli with itself (squaring)
+		{ X, X, I, 0 },
+		{ Y, Y, I, 0 },
+		{ Z, Z, I, 0 },
+
+		// Cyclic and anti-cyclic products
+		{ X, Y, Z, 1 }, // XY = iZ
+		{ Y, X, Z, -1 }, // YX = -iZ
+		{ Y, Z, X, 1 }, // YZ = iX
+		{ Z, Y, X, -1 }, // ZY = -iX
+		{ Z, X, Y, 1 }, // ZX = iY
+		{ X, Z, Y, -1 } // XZ = -iY
+	} };
+
+	for (auto const& [p1_start, p2, expected_pauli, expected_phase] : truth_table) {
+		Pauli p1 = p1_start; // Create a mutable copy to test in-place modification
+		int phase = p1.multiply_right(p2);
+
+		// Assert that the object was correctly modified in-place
+		ASSERT_EQ(p1, expected_pauli);
+
+		// Assert that the correct phase was returned
+		ASSERT_EQ(phase, expected_phase);
+	}
 }

--- a/tests/pauli_axis.cpp
+++ b/tests/pauli_axis.cpp
@@ -1,0 +1,28 @@
+#include <vector>
+#include "gtest/gtest.h"
+
+#include "pauli_axis.hpp"
+#include "pauli.hpp"
+
+TEST(PauliAxis, init) {
+	std::vector<Pauli> paulis{ p_i, p_x, p_y, p_z };
+	PauliAxis<> axis{ paulis };
+	PauliAxis<> axis2{ paulis.begin(), paulis.end() };
+	EXPECT_EQ(axis.raw_bits(), std::vector<std::uint8_t>{ 0b11100100 });
+	EXPECT_EQ(axis2.raw_bits(), std::vector<std::uint8_t>{ 0b11100100 });
+}
+
+TEST(PauliAxis, size) {
+	std::vector<Pauli> paulis{ p_i, p_x, p_y, p_z };
+	PauliAxis<> axis{ paulis };
+	EXPECT_EQ(axis.nb_qubits(), paulis.size());
+}
+
+TEST(PauliAxis, access_pauli) {
+	std::vector<Pauli> paulis{ p_i, p_x, p_y, p_z };
+	PauliAxis<> axis{ paulis };
+	ASSERT_EQ(axis.nb_qubits(), paulis.size());
+	for (std::size_t i = 0; i < paulis.size(); ++i) {
+		EXPECT_EQ(axis[i], paulis[i]);
+	}
+}

--- a/tests/pauli_bitwise.cpp
+++ b/tests/pauli_bitwise.cpp
@@ -1,0 +1,115 @@
+#include "gtest/gtest.h"
+
+// Your project's headers
+#include "pauli_term_container.hpp"
+#include "container/pauli_bitwise.hpp"
+
+#include <vector>
+#include <string>
+#include <numeric>
+
+// A test fixture to set up the container and provide helper methods.
+class PauliTermPackedBitwiseTest : public ::testing::Test {
+    protected:
+	// Helper to convert a human-readable string into the packed byte format.
+	PauliAxis<> pauli_string_to_axis(const std::string& pauli_str) {
+		std::vector<Pauli> paulis{ pauli_str.begin(), pauli_str.end() };
+		return PauliAxis<>{ paulis };
+	}
+
+	// A container to hold our test terms. Let's use 10 qubits to test across byte boundaries.
+	using PTC = PauliTermContainer<float, uint8_t>;
+};
+
+// Test case 1: Trivial commutation with an all-Identity axis.
+TEST_F(PauliTermPackedBitwiseTest, CommutesWithIdentity) {
+	const std::string term_str = "XZYIXZYIXZ";
+	const std::string axis_str = "IIIIIIIIII";
+
+	PTC ptc{ term_str };
+
+	auto term_view = ptc[0];
+	auto axis = pauli_string_to_axis(axis_str);
+
+	// Everything commutes with Identity. The anti-commute count should be 0 (even).
+	ASSERT_TRUE(term_view.commutes_with(axis.raw_bits()));
+}
+
+// Test case 2: Commutation of a term with itself.
+TEST_F(PauliTermPackedBitwiseTest, CommutesWhenIdentical) {
+	const std::string term_str = "XZYIXZYIXZ";
+
+	PTC ptc{ term_str };
+	auto term_view = ptc[0];
+	auto axis = pauli_string_to_axis(term_str);
+
+	// A Pauli string always commutes with itself (0 anti-commuting sites).
+	ASSERT_TRUE(term_view.commutes_with(axis.raw_bits()));
+}
+
+// Test case 3: Cases with an even or odd number of anti-commuting sites.
+TEST_F(PauliTermPackedBitwiseTest, CommutationWithMixedSites) {
+	// Part 1: Even number of anti-commuting sites -> COMMUTES
+	const std::string term_str_even = "XYXY";
+	const std::string axis_str_even = "YXYX";
+
+	PTC ptc_even{ term_str_even };
+	auto term_view_even = ptc_even[0];
+	auto axis_even = pauli_string_to_axis(axis_str_even);
+
+	// Count: X,Y (anti) | Y,X (anti) | X,Y (anti) | Y,X (anti)
+	// Total anti-commuting sites = 4 (even). They should COMMUTE.
+	ASSERT_TRUE(term_view_even.commutes_with(axis_even.raw_bits()));
+
+	// Part 2: Odd number of anti-commuting sites -> ANTI-COMMUTES
+	const std::string term_str_odd = "XYIIZ";
+	const std::string axis_str_odd = "YZIIX";
+
+	PTC ptc_odd{ term_str_odd };
+	auto term_view_odd = ptc_odd[0];
+	auto axis_odd = pauli_string_to_axis(axis_str_odd);
+
+	// Count: X,Y (anti) | Y,Z (anti) | I,I (commute) | I,I (commute) | Z,X (anti)
+	// Total anti-commuting sites = 3 (odd). They should ANTI-COMMUTE.
+	ASSERT_FALSE(term_view_odd.commutes_with(axis_odd.raw_bits()));
+}
+
+// Test case 4: Simple anti-commutation with a single anti-commuting site.
+TEST_F(PauliTermPackedBitwiseTest, AntiCommutesWithSingleSite) {
+	const std::string term_str = "ZIIIIIIIII";
+	const std::string axis_str = "XIIIIIIIII";
+
+	PTC ptc{ term_str };
+	auto term_view = ptc[0];
+	auto axis = pauli_string_to_axis(axis_str);
+
+	// Only the first site (Z and X) anti-commutes. Count is 1 (odd).
+	ASSERT_FALSE(term_view.commutes_with(axis.raw_bits()));
+}
+
+// Test case 5: A longer, more complex case to test logic across byte boundaries.
+TEST_F(PauliTermPackedBitwiseTest, CommutationWithComplexStrings) {
+	// Part 1: An even number of anti-commuting sites -> COMMUTES
+	const std::string term_str_even = "ZXIYIZXIYI"; // 10 qubits
+	const std::string axis_str_even = "YIZXIYIZXI";
+
+	PTC ptc_even{ term_str_even };
+	auto term_view_even = ptc_even[0];
+	auto axis_even = pauli_string_to_axis(axis_str_even);
+
+	// Count: Z,Y(a) | X,I(c) | I,Z(c) | Y,X(a) | I,I(c) -> 2 anti-commuting sites
+	// This pattern repeats. Total = 2 + 2 = 4 (even). They should COMMUTE.
+	ASSERT_TRUE(term_view_even.commutes_with(axis_even.raw_bits()));
+
+	// Part 2: An odd number of anti-commuting sites -> ANTI-COMMUTES
+	const std::string term_str_odd = "XXXYYYZZZ"; // 9 qubits
+	const std::string axis_str_odd = "YYYZZZXXX";
+
+	PTC ptc_odd{ term_str_odd };
+	auto term_view_odd = ptc_odd[0];
+	auto axis_odd = pauli_string_to_axis(axis_str_odd);
+
+	// Count: X,Y(a) x3 | Y,Z(a) x3 | Z,X(a) x3
+	// Total anti-commuting sites = 3 + 3 + 3 = 9 (odd). They should ANTI-COMMUTE.
+	ASSERT_FALSE(term_view_odd.commutes_with(axis_odd.raw_bits()));
+}

--- a/tests/symbolic_circuit.cpp
+++ b/tests/symbolic_circuit.cpp
@@ -88,8 +88,17 @@ TEST(SymbolicCircuit, run_rz_var) {
 	qc.add_operation("H", 1);
 
 	auto res = qc.run(So_t{ "IZ", "ZI" });
-	EXPECT_NEAR(res.expectation_value().evaluate({ { "a", 3.14159 / 3.f }, { "b", 3.14159 / 4.f } }), 1.207108,
-		    1e-4f);
+	EXPECT_NEAR(res.expectation_value().evaluate({ { "a", 3.14159 / 3.f }, { "b", 3.14159 / 4.f } }), 1.207108, 1e-4f);
+}
+
+TEST(SymbolicCircuit, run_rp_var) {
+	Sc_t qc{ 4 };
+	std::vector<Pauli> H{ { p_x, p_x, p_x, p_x } };
+
+	qc.eiht(H, Variable("t"));
+
+	auto res = qc.run(So_t{ "ZIII" });
+	EXPECT_NEAR(res.expectation_value().evaluate({ { "t", 1.f } }), -0.4161468365471419f, 1e-4f);
 }
 
 TEST(SymbolicCircuit, run_unital_noise_const) {
@@ -167,6 +176,5 @@ TEST(SymbolicCircuit, noise_model_var) {
 	sqc.add_operation("cx", 0, 1);
 
 	auto res = sqc.run({ "ZZ" });
-	EXPECT_NEAR(res.expectation_value().evaluate({ { "p_ad", 0.1f }, { "p_deph", 0.01f }, { "p_depo", 0.01f } }),
-		    0.0100, 1e-5f);
+	EXPECT_NEAR(res.expectation_value().evaluate({ { "p_ad", 0.1f }, { "p_deph", 0.01f }, { "p_depo", 0.01f } }), 0.0100, 1e-5f);
 }

--- a/tests/symbolic_observable.cpp
+++ b/tests/symbolic_observable.cpp
@@ -175,10 +175,8 @@ TYPED_TEST(SymbolicObservableTest, apply_rz_constant) {
 		} else if (!pt2[i].commutes_with(p_z)) {
 			pts.push_back(pt2.apply_rz(i, theta));
 		}
-		auto expected_ev =
-			std::accumulate(pts.cbegin(), pts.cend(), coeff_t{ 0. }, [](auto acc, auto const& pt) {
-				return acc + pt.expectation_value().evaluate();
-			});
+		auto expected_ev = std::accumulate(pts.cbegin(), pts.cend(), coeff_t{ 0. },
+						   [](auto acc, auto const& pt) { return acc + pt.expectation_value().evaluate(); });
 
 		obs.apply_rz(i, theta, this->policy);
 
@@ -212,10 +210,8 @@ TYPED_TEST(SymbolicObservableTest, apply_rz_variable) {
 		} else if (!pt2[i].commutes_with(p_z)) {
 			pts.push_back(pt2.apply_rz(i, theta));
 		}
-		auto expected_ev =
-			std::accumulate(pts.cbegin(), pts.cend(), coeff_t{ 0. }, [](auto acc, auto const& pt) {
-				return acc + pt.expectation_value().evaluate();
-			});
+		auto expected_ev = std::accumulate(pts.cbegin(), pts.cend(), coeff_t{ 0. },
+						   [](auto acc, auto const& pt) { return acc + pt.expectation_value().evaluate(); });
 
 		obs.apply_rz(i, v_theta, this->policy);
 
@@ -229,12 +225,42 @@ TYPED_TEST(SymbolicObservableTest, apply_rz_variable) {
 	}
 }
 
+TYPED_TEST(SymbolicObservableTest, apply_rp_rzz_variable) {
+	So_t obs{ "IXYZZIXYYZXIZXIZI", "ZXYIXYZXZZZYYXXYY" };
+	So_t obs_cpy = obs;
+
+	const coeff_t theta = 1.41421356237;
+	Variable v_theta{ "theta" };
+
+	for (std::size_t i = 0; i < obs.size() - 1; ++i) {
+		auto obs = obs_cpy;
+		auto cpy = obs_cpy;
+
+		cpy.apply_cx(i, i + 1);
+		cpy.apply_rz(i + 1, theta);
+		cpy.apply_cx(i, i + 1);
+
+		std::vector<Pauli> axis(obs.nb_qubits(), p_i);
+		axis[i] = p_z;
+		axis[i + 1] = p_z;
+		obs.apply_rp(axis, v_theta, this->policy);
+
+		ASSERT_EQ(obs.size(), cpy.size());
+		for (std::size_t j = 0; j < obs.size(); ++j) { // find all terms inside observable
+			auto h = obs[j].phash();
+			auto it = std::find_if(cpy.begin(), cpy.end(), [=](auto const& p) { return p.phash() == h; });
+			ASSERT_NE(it, obs.end());
+		}
+		EXPECT_EQ(obs.expectation_value(this->policy).evaluate({ { "theta", theta } }),
+			  cpy.expectation_value(this->policy).evaluate());
+	}
+}
+
 TYPED_TEST(SymbolicObservableTest, expectation_value_is_simplified) {
 	EXPECT_EQ(to_string(So_t{ "ZI" }.expectation_value(this->policy).simplified()), "1");
 	EXPECT_EQ(to_string(So_t{ "IX" }.expectation_value(this->policy).simplified()), "0");
 	EXPECT_EQ(to_string(So_t{ "YZ" }.expectation_value(this->policy).simplified()), "0");
-	EXPECT_EQ(to_string(So_t{ { "ZI", Variable("theta") }, { "IX", 1 } }.expectation_value(this->policy).simplified()),
-		  "theta");
+	EXPECT_EQ(to_string(So_t{ { "ZI", Variable("theta") }, { "IX", 1 } }.expectation_value(this->policy).simplified()), "theta");
 }
 
 TYPED_TEST(SymbolicObservableTest, merge_works) {
@@ -265,8 +291,7 @@ TYPED_TEST(SymbolicObservableTest, truncate_never) {
 
 TYPED_TEST(SymbolicObservableTest, truncate_multi) {
 	So_t obs{ { "IXYZ", SymbolicCoefficient<coeff_t>{ -0.25 } }, { "IIII", 0.10 } };
-	auto mt = combine_truncators_raw(NeverTruncator<SymbolicCoefficient<coeff_t>>(),
-					 WeightTruncator<SymbolicCoefficient<coeff_t>>(3));
+	auto mt = combine_truncators_raw(NeverTruncator<SymbolicCoefficient<coeff_t>>(), WeightTruncator<SymbolicCoefficient<coeff_t>>(3));
 
 	auto nb_removed = obs.truncate(mt);
 	auto nb_elems_internal = std::distance(obs.cbegin(), obs.cend());


### PR DESCRIPTION
- Compute R_p(theta) for any Pauli axis in one go.
- Allows for efficient computation of exp(-iHt)

The code is optimized and use SIMD for commutations and pauli multiplication.