### PR TITLE
Support for native U3 gate

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ set(BENCHMARK OFF CACHE BOOL "Build benchmarks")
 set(TEST OFF CACHE BOOL "Build tests")
 
 project(ProPauli
-	VERSION 5.0.0
+	VERSION 5.1.0
 DESCRIPTION "Fast and efficient C++ library for Pauli Propagation"
 	LANGUAGES CXX)
 

--- a/benchmarks/observables.cpp
+++ b/benchmarks/observables.cpp
@@ -396,6 +396,31 @@ static void Observable_apply_rp_12times(benchmark::State& state) {
 	}
 }
 
+static void Observable_apply_u3_6times(benchmark::State& state) {
+    constexpr coeff_t theta = 1.0;
+    constexpr coeff_t phi = 2.0;
+    constexpr coeff_t lambda = 3.0;
+    
+    // Generate 1024 random observables of length state.range(0)
+    std::vector<Observable<coeff_t>> obses;
+    std::generate_n(std::back_inserter(obses), 1024, [&]() { 
+        return Observable<coeff_t>{ random_pauli_string(state.range(0)) }; 
+    });
+
+    std::size_t i = 0;
+    for (auto _ : state) {
+        state.PauseTiming();
+        auto obs = obses[i];
+        i = (i + 1) % 1024;
+        state.ResumeTiming();
+
+        // Stress test the matrix multiplication and 3-way branching
+        for (std::size_t j = 0; j < 6; ++j) {
+            obs.apply_u3(0, theta, phi, lambda);
+        }
+    }
+}
+
 BENCHMARK(Observable_init_from_string)->Arg(1)->Arg(1024);
 BENCHMARK(Observable_apply_pauli)->Arg(1)->Arg(1024);
 BENCHMARK(Observable_apply_clifford)->Arg(1)->Arg(1024);
@@ -403,6 +428,7 @@ BENCHMARK(Observable_apply_unital_noise)->Arg(1)->Arg(1024);
 BENCHMARK(Observable_apply_rz_once)->Arg(1)->Arg(1024);
 BENCHMARK(Observable_apply_rp_12times)->Arg(8)->Arg(64)->Arg(1024);
 BENCHMARK(Observable_apply_rz_ntimes)->Args({ 1024, 16 });
+BENCHMARK(Observable_apply_u3_6times)->Arg(8)->Arg(64)->Arg(1024);
 BENCHMARK(Observable_ev_after_nrz)->Args({ 1024, 16 });
 BENCHMARK(Observable_merge_after_nrz)->Args({ 8, 16 })->Args({ 1024, 1 })->Args({ 1024, 8 });
 BENCHMARK(Observable_truncate_coeff_after_nrz)->Args({ 8, 16 })->Args({ 1024, 1 })->Args({ 1024, 8 });

--- a/include/circuit.hpp
+++ b/include/circuit.hpp
@@ -110,6 +110,7 @@ class Circuit {
 									 { "CX", Cx },
 									 { "RZ", Rz },
 									 { "RP", Rp },
+									 { "U3", U3 },
 									 { "AMPLITUDEDAMPING", AmplitudeDamping },
 									 { "DEPOLARIZING", Depolarizing },
 									 { "DEPHASING", Dephasing } };
@@ -149,6 +150,9 @@ class Circuit {
 	void rp(std::vector<Pauli> const& pauli_axis, Coefficient_t const& coeff) { add_operation(QGate::Rp, pauli_axis, coeff); }
 	void eiht(std::vector<Pauli> const& pauli_axis, Coefficient_t const& t) {
 		add_operation(QGate::Rp, pauli_axis, t * Coefficient_t{ 2 });
+	}
+	void u3(unsigned qubit, Coefficient_t const& theta, Coefficient_t const& phi, Coefficient_t const& lambda) {
+		add_operation(QGate::U3, qubit, theta, phi, lambda);
 	}
 
 	/**
@@ -326,6 +330,12 @@ class Circuit {
 		if (axis.size() != nb_qubits()) {
 			throw std::invalid_argument("Axis length for Rp gate should match circuit size.");
 		}
+	}
+
+	template <typename Real>
+	void check_args(unsigned qubit, [[maybe_unused]] Real&& theta, [[maybe_unused]] Real&& phi, [[maybe_unused]] Real&& lambda)
+		requires(std::is_floating_point_v<std::remove_cvref_t<Real>> || Symbolic<std::remove_cvref_t<Real>>) {
+		check_args(qubit);
 	}
 
 	/**

--- a/include/container/packed_pauli_term.inl
+++ b/include/container/packed_pauli_term.inl
@@ -401,9 +401,9 @@ class NonOwningPauliTermPacked {
 
 		/*
 		* M_{total} = \begin{pmatrix}
-			\cos\lambda \cos\theta \cos\phi - \sin\lambda \sin\phi & -\cos\lambda \cos\theta \sin\phi - \sin\lambda \cos\phi & \cos\lambda \sin\theta \\
-			\sin\lambda \cos\theta \cos\phi + \cos\lambda \sin\phi & -\sin\lambda \cos\theta \sin\phi + \cos\lambda \cos\phi & \sin\lambda \sin\theta \\
-			-\sin\theta \cos\phi & \sin\theta \sin\phi & \cos\theta
+			\cos\lambda \cos\theta \cos\phi - \sin\lambda \sin\phi & \cos\lambda \cos\theta \sin\phi + \sin\lambda \cos\phi & -\cos\lambda \sin\theta \\
+			-\sin\lambda \cos\theta \cos\phi - \cos\lambda \sin\phi & -\sin\lambda \cos\theta \sin\phi + \cos\lambda \cos\phi & \sin\lambda \sin\theta \\
+			\sin\theta \cos\phi & \sin\theta \sin\phi & \cos\theta
 		\end{pmatrix} */
 
 		const auto cos_theta = cos(theta);
@@ -419,15 +419,15 @@ class NonOwningPauliTermPacked {
 			set_coefficient(old_coeff * (cos_lambda * cos_theta * cos_phi - sin_lambda * sin_phi));
 
 			branch_one.set_pauli(qubit, p_y);
-			branch_one.set_coefficient(old_coeff * (sin_lambda * cos_theta * cos_phi + cos_lambda * sin_phi));
+			branch_one.set_coefficient(old_coeff * (-sin_lambda * cos_theta * cos_phi - cos_lambda * sin_phi));
 
 			branch_two.set_pauli(qubit, p_z);
-			branch_two.set_coefficient(old_coeff * (-sin_theta * cos_phi));
+			branch_two.set_coefficient(old_coeff * (sin_theta * cos_phi));
 		} else if (get_pauli(qubit) == p_y) {
 			set_coefficient(old_coeff * (-sin_lambda * cos_theta * sin_phi + cos_lambda * cos_phi));
 
 			branch_one.set_pauli(qubit, p_x);
-			branch_one.set_coefficient(old_coeff * (-cos_lambda * cos_theta * sin_phi - sin_lambda * cos_phi));
+			branch_one.set_coefficient(old_coeff * (cos_lambda * cos_theta * sin_phi + sin_lambda * cos_phi));
 
 			branch_two.set_pauli(qubit, p_z);
 			branch_two.set_coefficient(old_coeff * (sin_theta * sin_phi));
@@ -435,7 +435,7 @@ class NonOwningPauliTermPacked {
 			set_coefficient(old_coeff * (cos_theta));
 
 			branch_one.set_pauli(qubit, p_x);
-			branch_one.set_coefficient(old_coeff * (cos_lambda * sin_theta));
+			branch_one.set_coefficient(old_coeff * (-cos_lambda * sin_theta));
 
 			branch_two.set_pauli(qubit, p_y);
 			branch_two.set_coefficient(old_coeff * (sin_lambda * sin_theta));

--- a/include/container/packed_pauli_term.inl
+++ b/include/container/packed_pauli_term.inl
@@ -394,6 +394,53 @@ class NonOwningPauliTermPacked {
 		T const sign = (((i_pow % 4) + 4) % 4 == 2) ? T{ -1 } : T{ 1 };
 		output.set_coefficient(old_coeff * sin_theta * sign);
 	}
+	void apply_u3(unsigned qubit, T theta, T phi, T lambda, NonOwningPauliTermPacked& branch_one,
+		      NonOwningPauliTermPacked& branch_two) {
+		assert(qubit < size());
+		assert(get_pauli(qubit) != p_i && "Should not happen");
+
+		/*
+		* M_{total} = \begin{pmatrix}
+			\cos\lambda \cos\theta \cos\phi - \sin\lambda \sin\phi & -\cos\lambda \cos\theta \sin\phi - \sin\lambda \cos\phi & \cos\lambda \sin\theta \\
+			\sin\lambda \cos\theta \cos\phi + \cos\lambda \sin\phi & -\sin\lambda \cos\theta \sin\phi + \cos\lambda \cos\phi & \sin\lambda \sin\theta \\
+			-\sin\theta \cos\phi & \sin\theta \sin\phi & \cos\theta
+		\end{pmatrix} */
+
+		const auto cos_theta = cos(theta);
+		const auto sin_theta = sin(theta);
+		const auto cos_phi = cos(phi);
+		const auto sin_phi = sin(phi);
+		const auto cos_lambda = cos(lambda);
+		const auto sin_lambda = sin(lambda);
+
+		const auto old_coeff = coefficient();
+
+		if (get_pauli(qubit) == p_x) {
+			set_coefficient(old_coeff * (cos_lambda * cos_theta * cos_phi - sin_lambda * sin_phi));
+
+			branch_one.set_pauli(qubit, p_y);
+			branch_one.set_coefficient(old_coeff * (sin_lambda * cos_theta * cos_phi + cos_lambda * sin_phi));
+
+			branch_two.set_pauli(qubit, p_z);
+			branch_two.set_coefficient(old_coeff * (-sin_theta * cos_phi));
+		} else if (get_pauli(qubit) == p_y) {
+			set_coefficient(old_coeff * (-sin_lambda * cos_theta * sin_phi + cos_lambda * cos_phi));
+
+			branch_one.set_pauli(qubit, p_x);
+			branch_one.set_coefficient(old_coeff * (-cos_lambda * cos_theta * sin_phi - sin_lambda * cos_phi));
+
+			branch_two.set_pauli(qubit, p_z);
+			branch_two.set_coefficient(old_coeff * (sin_theta * sin_phi));
+		} else { // Z
+			set_coefficient(old_coeff * (cos_theta));
+
+			branch_one.set_pauli(qubit, p_x);
+			branch_one.set_coefficient(old_coeff * (cos_lambda * sin_theta));
+
+			branch_two.set_pauli(qubit, p_y);
+			branch_two.set_coefficient(old_coeff * (sin_lambda * sin_theta));
+		}
+	}
 	void apply_amplitude_damping_xy([[maybe_unused]] unsigned qubit, T p) {
 		assert(qubit < size());
 		assert(get_pauli(qubit) != p_z && get_pauli(qubit) != p_i && "Should not happen");

--- a/include/noise_model.hpp
+++ b/include/noise_model.hpp
@@ -80,6 +80,12 @@ class NoiseModel {
 	}
 
 	template <typename C, typename Real>
+	void apply_noise_after(C& qc, QGate cg, unsigned qubit, [[maybe_unused]] Real theta, [[maybe_unused]] Real phi, [[maybe_unused]] Real lambda)
+		requires(std::is_floating_point_v<Real> || Symbolic<Real>) {
+		apply_noise_after(qc, cg, qubit);
+	}
+
+	template <typename C, typename Real>
 	void apply_noise_after(C& qc, QGate cg, [[maybe_unused]] std::vector<Pauli> const& axis, [[maybe_unused]] Real theta)
 		requires(std::is_floating_point_v<Real> || Symbolic<Real>) {
 		for (std::size_t i = 0; i < qc.nb_qubits(); ++i) {

--- a/include/observable.hpp
+++ b/include/observable.hpp
@@ -205,6 +205,18 @@ class Observable {
 		return std::visit([&, this](auto const& pol) { return this->apply_rp(axis, theta, pol); }, rpol);
 	}
 
+	template <IsNotVariant ExecutionPolicy = DefaultExecutionPolicy>
+	void apply_u3(unsigned qubit, T theta, T phi, T lambda, ExecutionPolicy&& policy = ExecutionPolicy{}) {
+		check_qubit(qubit);
+		using Policy_t = std::remove_cvref_t<decltype(policy)>;
+		Policy_t::apply_u3(paulis_, qubit, theta, phi, lambda);
+	}
+
+	template <IsVariant DynamicPolicy>
+	void apply_u3(unsigned qubit, T theta, T phi, T lambda, DynamicPolicy&& rpol) {
+		return std::visit([&, this](auto const& pol) { return this->apply_u3(qubit, theta, phi, lambda, pol); }, rpol);
+	}
+
 	/**
 	 * @brief Applies an amplitude damping noise channel.
 	 * @param qubit The index of the qubit to apply the channel to.

--- a/include/pauli.hpp
+++ b/include/pauli.hpp
@@ -173,9 +173,9 @@ static constexpr auto unital_noise_map_coeff = init_unital_noise_array_coeff<coe
 static constexpr auto pauli_product_map = init_pauli_product_map();
 static constexpr auto pauli_product_phase_map = init_pauli_product_phase_map();
 
-enum class QGate : array_underlying_type { I, X, Y, Z, H, Rz, Rp, Cx, AmplitudeDamping, Depolarizing, Dephasing, Count };
+enum class QGate : array_underlying_type { I, X, Y, Z, H, Rz, Rp, U3, Cx, AmplitudeDamping, Depolarizing, Dephasing, Count };
 static_assert(std::to_underlying(QGate::Count) == (std::to_underlying(Pauli_gates::Count) + std::to_underlying(Clifford_Gates_1Q::Count) +
-						   std::to_underlying(UnitalNoise::Count) + 1 + 1 + 1 + 1));
+						   std::to_underlying(UnitalNoise::Count) + 1 + 1 + 1 + 1 + 1));
 
 /**
  * @brief Represents a single Pauli operator (I, X, Y, or Z).

--- a/include/policies/openmp.hpp
+++ b/include/policies/openmp.hpp
@@ -225,6 +225,55 @@ struct OpenMPPolicy {
 	}
 
 	template <typename PTC, typename T>
+	inline static void apply_u3(PTC& paulis, unsigned qubit, T theta, T phi, T lambda) {
+		const auto nb_terms = paulis.nb_terms();
+
+		std::vector<std::size_t> allocated_per_thread(omp_get_max_threads(), 0);
+		std::size_t total_to_allocate = 0;
+
+		#pragma omp parallel shared(allocated_per_thread)
+		{
+			auto tid = omp_get_thread_num();
+
+			// compute number of required nb_term
+			#pragma omp for reduction(+ : total_to_allocate) schedule(static)
+			for (std::size_t i = 0; i < nb_terms; ++i) {
+				if (paulis[i].get_pauli(qubit) != p_i) {
+					allocated_per_thread[tid]++;
+					total_to_allocate++;
+				}
+			}
+
+			// pre-alloc is mandatory to not invalidate terms while allocating
+			#pragma omp single
+			paulis._batch_allocate(2*total_to_allocate);
+
+			// get start_idx by computing sum of previous elements
+			std::size_t start_idx = nb_terms;
+			for (int k = 0; k < tid; ++k) {
+				start_idx += 2 * allocated_per_thread[k];
+			}
+
+			std::size_t k_idx = 0; // allocated index
+
+			#pragma omp for schedule(static)
+			for (std::size_t i = 0; i < nb_terms; ++i) {
+				auto p = paulis[i];
+				if (paulis[i].get_pauli(qubit) != p_i) {
+					const auto tmp_pt_idx = start_idx + (2*k_idx);
+					auto new_path_one = paulis[tmp_pt_idx];
+					auto new_path_two = paulis[tmp_pt_idx+1];
+					new_path_one.fast_copy_content(p);
+					new_path_two.fast_copy_content(p);
+					p.apply_u3(qubit, theta, phi, lambda, new_path_one, new_path_two);
+					k_idx++;
+				}
+			}
+		}
+	}
+
+
+	template <typename PTC, typename T>
 	inline static void apply_amplitude_damping(PTC& paulis, unsigned qubit, T pn) {
 		const auto nb_terms = paulis.nb_terms();
 

--- a/include/policies/sequential.hpp
+++ b/include/policies/sequential.hpp
@@ -126,6 +126,36 @@ struct SequentialPolicy {
 	}
 
 	template <typename PTC, typename T>
+	inline static void apply_u3(PTC& paulis, unsigned qubit, T theta, T phi, T lambda) {
+		const auto nb_terms = paulis.nb_terms();
+
+		// compute number of required nb_term
+		std::size_t total_to_allocate = 0;
+		for (std::size_t i = 0; i < nb_terms; ++i) {
+			if (paulis[i].get_pauli(qubit) != p_i) {
+				total_to_allocate++;
+			}
+		}
+
+		// pre-alloc is mandatory to not invalidate terms while allocating
+		paulis._batch_allocate(2 * total_to_allocate); // NOTE: two branches created per u3
+
+		std::size_t k_idx = 0; // allocated index
+		for (std::size_t i = 0; i < nb_terms; ++i) {
+			auto p = paulis[i];
+			if (paulis[i].get_pauli(qubit) != p_i) {
+				const auto tmp_pt_idx = nb_terms + (2 * k_idx);
+				auto new_path_one = paulis[tmp_pt_idx];
+				auto new_path_two = paulis[tmp_pt_idx + 1];
+				new_path_one.fast_copy_content(p);
+				new_path_two.fast_copy_content(p);
+				p.apply_u3(qubit, theta, phi, lambda, new_path_one, new_path_two);
+				k_idx++;
+			}
+		}
+	}
+
+	template <typename PTC, typename T>
 	inline static void apply_amplitude_damping(PTC& paulis, unsigned qubit, T pn) {
 		const auto nb_terms = paulis.nb_terms();
 

--- a/include/quantum_op.hpp
+++ b/include/quantum_op.hpp
@@ -69,6 +69,8 @@ class QuantumOp {
 	unsigned qubit1;
 	PauliAxis<> axis;
 	T parameter;
+	T parameter2;
+	T parameter3;
 
     public:
 	using ObservableType = Observable<T>;
@@ -85,6 +87,15 @@ class QuantumOp {
 		: gate(qg), qubit0(qubit), parameter(std::move(v)) {
 		if (qg != QGate::Rz && !in_array(qg, unoise_map) && qg != QGate::AmplitudeDamping) {
 			throw std::invalid_argument("bad parameters for non parametric gate.");
+		}
+	}
+
+	template <typename Real>
+	QuantumOp(QGate qg, unsigned qubit, Real&& theta, Real&& phi, Real&& lambda)
+		requires(std::is_floating_point_v<std::remove_cvref_t<Real>> || Symbolic<std::remove_cvref_t<Real>>)
+		: gate(qg), qubit0(qubit), parameter(std::move(theta)), parameter2(std::move(phi)), parameter3(std::move(lambda)) {
+		if (qg != QGate::U3) {
+			throw std::invalid_argument("bad parameters for U3 gate.");
 		}
 	}
 
@@ -107,6 +118,8 @@ class QuantumOp {
 			return obs.apply_rz(qubit0, parameter, policy);
 		case QGate::Rp:
 			return obs.apply_rp(axis, parameter, policy);
+		case QGate::U3:
+			return obs.apply_u3(qubit0, parameter, parameter2, parameter3, policy);
 		case QGate::Cx:
 			return obs.apply_cx(qubit0, qubit1, policy);
 		case QGate::AmplitudeDamping:
@@ -137,8 +150,9 @@ class QuantumOp {
 	QGate get_gate() const { return gate; }
 
 	[[gnu::always_inline]] inline OperationType operation_type() const {
-		return (gate == QGate::Rz || gate == QGate::Rp || gate == QGate::AmplitudeDamping) ? OperationType::SplittingGate :
-												     OperationType::BasicGate;
+		return (gate == QGate::Rz || gate == QGate::Rp || gate == QGate::U3 || gate == QGate::AmplitudeDamping) ?
+			       OperationType::SplittingGate :
+			       OperationType::BasicGate;
 
 		// static constexpr std::array<OperationType, 2> arr_map{OperationType::BasicGate, OperationType::SplittingGate};
 		// return arr_map[gate == QGate::Rz || gate == QGate::AmplitudeDamping]; // branchless

--- a/tests/circuits.cpp
+++ b/tests/circuits.cpp
@@ -397,6 +397,7 @@ TYPED_TEST(CircuitRun, test_circuit1_batch_ev) {
 		EXPECT_NEAR(rev, exp, 1e-4f);
 	}
 }
+
 TYPED_TEST(CircuitRun, exp_iXXXXt) {
 	Circuit qc{ 4 };
 	Circuit qc_rp{ 4 };
@@ -450,6 +451,65 @@ TYPED_TEST(CircuitRun, exp_iXXXXt) {
 		auto [rev, err] = res_rp[i];
 		EXPECT_NEAR(rev, exp, 1e-4f);
 	}
+}
+
+TYPED_TEST(CircuitRun, apply_u3_hardcoded) {
+    Circuit qc_u3{ 1 };
+    Circuit qc_transpiled{ 1 };
+
+    constexpr coeff_t pi = 3.14159265358979323846;
+    const coeff_t theta = 1.0;
+    const coeff_t phi = 2.0;
+    const coeff_t lambda = 3.0;
+
+    // 1. Native U3 Circuit
+    qc_u3.add_operation("u3", 0, theta, phi, lambda);
+
+    // 2. Transpiled Circuit (Forward Execution Order)
+    // The forward application of Rz(phi) Ry(theta) Rz(lambda).
+    // Rz(lambda) -> (Rz(-pi/2) -> H -> Rz(theta) -> H -> Rz(pi/2)) -> Rz(phi)
+    // We seamlessly merge the adjacent Rz gates:
+    qc_transpiled.add_operation("rz", 0, lambda - pi / 2.0);
+    qc_transpiled.add_operation("h", 0);
+    qc_transpiled.add_operation("rz", 0, theta);
+    qc_transpiled.add_operation("h", 0);
+    qc_transpiled.add_operation("rz", 0, phi + pi / 2.0);
+
+    // 3. Analytical Expectation Values for U3(1.0, 2.0, 3.0) applied to |0>
+    // <X> = sin(theta) * cos(phi)
+    // <Y> = sin(theta) * sin(phi)
+    // <Z> = cos(theta)
+    std::array<std::tuple<std::string_view, coeff_t>, 3> truth_table = { {
+        { "X", -0.350175488f },
+        { "Y", 0.765147401f },
+        { "Z", 0.540302305f },
+    } };
+
+    std::vector<Observable<coeff_t>> obses;
+    for (auto const [ob, ev] : truth_table) {
+        // Assuming your Observable constructor takes the string
+        obses.push_back(Observable<coeff_t>{ ob });
+    }
+
+    // 4. Run the simulation
+    auto res_u3 = qc_u3.expectation_value(obses, this->policy);
+    auto res_transpiled = qc_transpiled.expectation_value(obses, this->policy);
+
+    // 5. Validate the results
+    for (std::size_t i = 0; i < res_u3.size(); ++i) {
+        auto exp = std::get<1>(truth_table[i]);
+        
+        // Destructure the [value, error] pairs returned by your API
+        auto [rev_u3, err_u3] = res_u3[i];
+        auto [rev_transpiled, err_transpiled] = res_transpiled[i];
+        
+        // Check both against the analytical truth table
+        EXPECT_NEAR(rev_u3, exp, 1e-4f);
+        EXPECT_NEAR(rev_transpiled, exp, 1e-4f);
+        
+        // Check that Native and Transpiled implementations match each other tightly
+        EXPECT_NEAR(rev_u3, rev_transpiled, 1e-5f);
+    }
 }
 
 TYPED_TEST(CircuitRun, bad_observable_throw) {

--- a/tests/observable.cpp
+++ b/tests/observable.cpp
@@ -285,6 +285,204 @@ TYPED_TEST(ObservableTest, apply_rz_inverse) {
 	EXPECT_EQ(before_ev, after_ev);
 }
 
+/* U3 test */
+
+// 1. Rx only (via U3(theta, -pi/2, pi/2))
+TYPED_TEST(ObservableTest, apply_u3_rx_only) {
+    constexpr coeff_t pi = 3.14159265358979323846;
+    constexpr coeff_t theta = 1.41421356237;
+    
+    Observable obs{ "X", "Y", "Z" };
+    Observable cpy = obs;
+
+    // U3(theta, -pi/2, pi/2) applies a pure Rx(theta)
+    obs.apply_u3(0, theta, -pi / 2.0, pi / 2.0, this->rpolicy);
+    obs.merge(this->rpolicy);
+
+    // Equivalent Rx(theta) = H Rz(theta) H
+    cpy.apply_clifford(Clifford_Gates_1Q::H, 0, this->rpolicy);
+    cpy.apply_rz(0, theta, this->rpolicy);
+    cpy.apply_clifford(Clifford_Gates_1Q::H, 0, this->rpolicy);
+    cpy.merge(this->rpolicy);
+
+    EXPECT_NEAR(obs.expectation_value(this->rpolicy), cpy.expectation_value(this->rpolicy), 1e-5f);
+    ASSERT_LE(obs.size(), cpy.size());
+    for (std::size_t j = 0; j < obs.size(); ++j) {
+        auto h = obs[j].phash();
+        auto it = std::find_if(cpy.begin(), cpy.end(), [=](auto const& p) { return p.phash() == h; });
+        ASSERT_NE(it, cpy.end());
+    }
+}
+
+// 2. Ry only (via decomposition)
+TYPED_TEST(ObservableTest, apply_u3_ry_only) {
+    constexpr coeff_t pi = 3.14159265358979323846;
+    constexpr coeff_t theta = 1.41421356237;
+    
+    Observable obs{ "X", "Y", "Z" };
+    Observable cpy = obs;
+
+    // Pure Ry(theta)
+    obs.apply_u3(0, theta, 0.0, 0.0, this->rpolicy);
+    obs.merge(this->rpolicy);
+
+    // Equivalent Ry(theta) = Rz(pi/2) H Rz(theta) H Rz(-pi/2)
+    cpy.apply_rz(0, pi / 2.0, this->rpolicy);
+    cpy.apply_clifford(Clifford_Gates_1Q::H, 0, this->rpolicy);
+    cpy.apply_rz(0, theta, this->rpolicy);
+    cpy.apply_clifford(Clifford_Gates_1Q::H, 0, this->rpolicy);
+    cpy.apply_rz(0, -pi / 2.0, this->rpolicy);
+    cpy.merge(this->rpolicy);
+
+    EXPECT_NEAR(obs.expectation_value(this->rpolicy), cpy.expectation_value(this->rpolicy), 1e-5f);
+    ASSERT_LE(obs.size(), cpy.size());
+    for (std::size_t j = 0; j < obs.size(); ++j) {
+        auto h = obs[j].phash();
+        auto it = std::find_if(cpy.begin(), cpy.end(), [=](auto const& p) { return p.phash() == h; });
+        ASSERT_NE(it, cpy.end());
+    }
+}
+
+// 3. Rz only
+TYPED_TEST(ObservableTest, apply_u3_rz_only) {
+    constexpr coeff_t alpha = 0.8414709848;
+    
+    Observable obs{ "X", "Y", "Z" };
+    Observable cpy = obs;
+
+    // Pure Rz(alpha)
+    obs.apply_u3(0, 0.0, 0.0, alpha, this->rpolicy);
+    obs.merge(this->rpolicy);
+
+    // Equivalent Rz(alpha)
+    cpy.apply_rz(0, alpha, this->rpolicy);
+    cpy.merge(this->rpolicy);
+
+    EXPECT_NEAR(obs.expectation_value(this->rpolicy), cpy.expectation_value(this->rpolicy), 1e-5f);
+    ASSERT_LE(obs.size(), cpy.size());
+    for (std::size_t j = 0; j < obs.size(); ++j) {
+        auto h = obs[j].phash();
+        auto it = std::find_if(cpy.begin(), cpy.end(), [=](auto const& p) { return p.phash() == h; });
+        ASSERT_NE(it, cpy.end());
+    }
+}
+
+// 4. Theta only (Functionally identical to Ry, but isolates the parameter)
+TYPED_TEST(ObservableTest, apply_u3_theta_only) {
+    constexpr coeff_t pi = 3.14159265358979323846;
+    constexpr coeff_t theta = 1.123456;
+    
+    Observable obs{ "X", "Y", "Z" };
+    Observable cpy = obs;
+
+    // U3(theta, 0, 0)
+    obs.apply_u3(0, theta, 0.0, 0.0, this->rpolicy);
+    obs.merge(this->rpolicy);
+
+    // Equivalent Ry(theta) sequence
+    cpy.apply_rz(0, pi / 2.0, this->rpolicy);
+    cpy.apply_clifford(Clifford_Gates_1Q::H, 0, this->rpolicy);
+    cpy.apply_rz(0, theta, this->rpolicy);
+    cpy.apply_clifford(Clifford_Gates_1Q::H, 0, this->rpolicy);
+    cpy.apply_rz(0, -pi / 2.0, this->rpolicy);
+    cpy.merge(this->rpolicy);
+
+    EXPECT_NEAR(obs.expectation_value(this->rpolicy), cpy.expectation_value(this->rpolicy), 1e-5f);
+    ASSERT_LE(obs.size(), cpy.size());
+    for (std::size_t j = 0; j < obs.size(); ++j) {
+        auto h = obs[j].phash();
+        auto it = std::find_if(cpy.begin(), cpy.end(), [=](auto const& p) { return p.phash() == h; });
+        ASSERT_NE(it, cpy.end());
+    }
+}
+
+// 5. Phi only (Isolates the Z phase before the Y rotation)
+TYPED_TEST(ObservableTest, apply_u3_phi_only) {
+    constexpr coeff_t phi = 0.456789;
+    
+    Observable obs{ "X", "Y", "Z" };
+    Observable cpy = obs;
+
+    // U3(0, phi, 0) simplifies to Rz(phi)
+    obs.apply_u3(0, 0.0, phi, 0.0, this->rpolicy);
+    obs.merge(this->rpolicy);
+
+    // Equivalent
+    cpy.apply_rz(0, phi, this->rpolicy);
+    cpy.merge(this->rpolicy);
+
+    EXPECT_NEAR(obs.expectation_value(this->rpolicy), cpy.expectation_value(this->rpolicy), 1e-5f);
+    ASSERT_LE(obs.size(), cpy.size());
+    for (std::size_t j = 0; j < obs.size(); ++j) {
+        auto h = obs[j].phash();
+        auto it = std::find_if(cpy.begin(), cpy.end(), [=](auto const& p) { return p.phash() == h; });
+        ASSERT_NE(it, cpy.end());
+    }
+}
+
+// 6. Lambda only (Isolates the Z phase after the Y rotation)
+TYPED_TEST(ObservableTest, apply_u3_lambda_only) {
+    constexpr coeff_t lambda = 0.789123;
+    
+    Observable obs{ "X", "Y", "Z" };
+    Observable cpy = obs;
+
+    // U3(0, 0, lambda) simplifies to Rz(lambda)
+    obs.apply_u3(0, 0.0, 0.0, lambda, this->rpolicy);
+    obs.merge(this->rpolicy);
+
+    // Equivalent
+    cpy.apply_rz(0, lambda, this->rpolicy);
+    cpy.merge(this->rpolicy);
+
+    EXPECT_NEAR(obs.expectation_value(this->rpolicy), cpy.expectation_value(this->rpolicy), 1e-5f);
+    ASSERT_LE(obs.size(), cpy.size());
+    for (std::size_t j = 0; j < obs.size(); ++j) {
+        auto h = obs[j].phash();
+        auto it = std::find_if(cpy.begin(), cpy.end(), [=](auto const& p) { return p.phash() == h; });
+        ASSERT_NE(it, cpy.end());
+    }
+}
+
+// 7. Full U3 (Combines all rotations)
+TYPED_TEST(ObservableTest, apply_u3_full) {
+    constexpr coeff_t pi = 3.14159265358979323846;
+    constexpr coeff_t theta = 1.123456;
+    constexpr coeff_t phi = 0.456789;
+    constexpr coeff_t lambda = 0.789123;
+    
+    Observable obs{ "X", "Y", "Z" };
+    Observable cpy = obs;
+
+    // Full U3
+    obs.apply_u3(0, theta, phi, lambda, this->rpolicy);
+    obs.merge(this->rpolicy);
+
+    // Equivalent sequence: Rz(phi) -> Ry(theta) -> Rz(lambda)
+    // 1. Rz(phi)
+    cpy.apply_rz(0, phi, this->rpolicy);
+    
+    // 2. Ry(theta)
+    cpy.apply_rz(0, pi / 2.0, this->rpolicy);
+    cpy.apply_clifford(Clifford_Gates_1Q::H, 0, this->rpolicy);
+    cpy.apply_rz(0, theta, this->rpolicy);
+    cpy.apply_clifford(Clifford_Gates_1Q::H, 0, this->rpolicy);
+    cpy.apply_rz(0, -pi / 2.0, this->rpolicy);
+    
+    // 3. Rz(lambda)
+    cpy.apply_rz(0, lambda, this->rpolicy);
+    
+    cpy.merge(this->rpolicy);
+
+    EXPECT_NEAR(obs.expectation_value(this->rpolicy), cpy.expectation_value(this->rpolicy), 1e-5f);
+    ASSERT_LE(obs.size(), cpy.size());
+    for (std::size_t j = 0; j < obs.size(); ++j) {
+        auto h = obs[j].phash();
+        auto it = std::find_if(cpy.begin(), cpy.end(), [=](auto const& p) { return p.phash() == h; });
+        ASSERT_NE(it, cpy.end());
+    }
+}
+
 TYPED_TEST(ObservableTest, expectation_value) {
 	EXPECT_EQ(Observable{ "ZI" }.expectation_value(this->rpolicy), 1);
 	EXPECT_EQ(Observable{ "IX" }.expectation_value(this->rpolicy), 0);

--- a/tests/qops.cpp
+++ b/tests/qops.cpp
@@ -90,6 +90,7 @@ TYPED_TEST_P(QuantumOpTest, Properties_AreCorrectForAllGates) {
 		{ "Cx", QOp(QGate::Cx, 0, 1), OperationType::BasicGate },
 		{ "Depolarizing", QOp(QGate::Depolarizing, 0, Real(0.1)), OperationType::BasicGate },
 		{ "Rz", QOp(QGate::Rz, 0, Real(0.1)), OperationType::SplittingGate },
+		{ "U3", QOp(QGate::U3, 0, Real(0.1), Real(0.1), Real(0.1)), OperationType::SplittingGate },
 		{ "AmplitudeDamping", QOp(QGate::AmplitudeDamping, 0, Real(0.1)), OperationType::SplittingGate }
 	};
 
@@ -121,6 +122,8 @@ TYPED_TEST_P(QuantumOpTest, Application_AllGatesDispatchCorrectlyOnAllObservable
 		{ "H", [] { return QOp(QGate::H, 0); }, [](auto& obs, auto&) { obs.apply_clifford(Clifford_Gates_1Q::H, 0); } },
 		{ "Rz", [] { return QOp(QGate::Rz, 0, Real(0.785)); },
 		  [](auto& obs, auto& policy) { obs.apply_rz(0, Real(0.785), policy); } },
+		{ "U3", [] { return QOp(QGate::U3, 0, Real(0.785), Real(0.5), Real(0.5)); },
+		  [](auto& obs, auto& policy) { obs.apply_u3(0, Real(0.785), Real(0.5), Real(0.5), policy); } },
 		{ "Cx", [] { return QOp(QGate::Cx, 0, 1); }, [](auto& obs, auto& policy) { obs.apply_cx(0, 1, policy); } },
 		{ "Depolarizing", [] { return QOp(QGate::Depolarizing, 0, Real(0.2)); },
 		  [](auto& obs, auto& policy) { obs.apply_unital_noise(UnitalNoise::Depolarizing, 0, Real(0.2), policy); } },

--- a/tests/symbolic_circuit.cpp
+++ b/tests/symbolic_circuit.cpp
@@ -101,6 +101,16 @@ TEST(SymbolicCircuit, run_rp_var) {
 	EXPECT_NEAR(res.expectation_value().evaluate({ { "t", 1.f } }), -0.4161468365471419f, 1e-4f);
 }
 
+TEST(SymbolicCircuit, run_u3_var) {
+	Sc_t qc{ 1 };
+
+	qc.u3(0, Variable("theta"), Variable("phi"), Variable("lambda"));
+
+	auto res = qc.run(So_t{ "X" });
+	EXPECT_NEAR(res.expectation_value().evaluate({ { "theta", 1.f }, { "phi", 2.0f }, { "lambda", 3.0f } }), -0.35017548837401463f,
+		    1e-4f);
+}
+
 TEST(SymbolicCircuit, run_unital_noise_const) {
 	Sc_t qc{ 2 };
 

--- a/tests/symbolic_observable.cpp
+++ b/tests/symbolic_observable.cpp
@@ -225,6 +225,58 @@ TYPED_TEST(SymbolicObservableTest, apply_rz_variable) {
 	}
 }
 
+TYPED_TEST(SymbolicObservableTest, apply_u3_variable) {
+	// Testing X, Y, and Z bases simultaneously
+	So_t obs{ "X", "Y", "Z" };
+	So_t obs_cpy = obs;
+
+	// Define our constants
+	constexpr coeff_t pi = 3.14159265358979323846;
+	const coeff_t t_val = 1.123456;
+	const coeff_t p_val = 0.456789;
+	const coeff_t l_val = 0.789123;
+
+	// Define symbolic variables
+	Variable v_theta{ "theta" };
+	Variable v_phi{ "phi" };
+	Variable v_lambda{ "lambda" };
+
+	auto cpy = obs_cpy;
+
+	// 1. Symbolic Application (U3)
+	obs.apply_u3(0, v_theta, v_phi, v_lambda, this->policy);
+	obs.merge(this->policy);
+
+	// 2. Numeric Transpiled Application (H + Rz)
+	// Applied in reverse circuit execution order: Rz(phi) -> Ry(theta) -> Rz(lambda)
+	cpy.apply_rz(0, p_val, this->policy);
+
+	// Ry transpilation
+	cpy.apply_rz(0, pi / 2.0, this->policy);
+	cpy.apply_clifford(Clifford_Gates_1Q::H, 0, this->policy);
+	cpy.apply_rz(0, t_val, this->policy);
+	cpy.apply_clifford(Clifford_Gates_1Q::H, 0, this->policy);
+	cpy.apply_rz(0, -pi / 2.0, this->policy);
+
+	cpy.apply_rz(0, l_val, this->policy);
+
+	cpy.merge(this->policy);
+
+	// 3. Validate terms match structurally
+	ASSERT_LE(obs.size(), cpy.size());
+	for (std::size_t j = 0; j < obs.size(); ++j) {
+		auto h = obs[j].phash();
+		auto it = std::find_if(cpy.begin(), cpy.end(), [=](auto const& p) { return p.phash() == h; });
+		ASSERT_NE(it, cpy.end()); // Note: fixed from obs.end() to cpy.end()
+	}
+
+	// 4. Validate symbolic evaluation against numeric sequence
+	// Note: Using EXPECT_NEAR instead of EXPECT_EQ to account for floating point drift
+	// between the trigonometric functions in evaluate() and sequential numeric matrices.
+	EXPECT_NEAR(obs.expectation_value(this->policy).evaluate({ { "theta", t_val }, { "phi", p_val }, { "lambda", l_val } }),
+		    cpy.expectation_value(this->policy).evaluate(), 1e-5f);
+}
+
 TYPED_TEST(SymbolicObservableTest, apply_rp_rzz_variable) {
 	So_t obs{ "IXYZZIXYYZXIZXIZI", "ZXYIXYZXZZZYYXXYY" };
 	So_t obs_cpy = obs;


### PR DESCRIPTION
This PR adds support for a native U3 gate. This should help accelerate circuits and improve precision.

This implementation only produces 2 new branches, instead of the 8 generated when 3 Rz are used because of transpilation.